### PR TITLE
Add variable path to exception msg when recursive-loop encountered

### DIFF
--- a/source/Octostache/Templates/EvaluationContext.cs
+++ b/source/Octostache/Templates/EvaluationContext.cs
@@ -38,7 +38,8 @@ namespace Octostache.Templates
             {
                 if (ancestor.symbolStack.Contains(expression, SymbolExpression.StepsComparer))
                 {
-                    throw new InvalidOperationException(string.Format("An attempt to parse the variable symbol \"{0}\" appears to have resulted in a self referencing loop. Ensure that recursive loops do not exist in the variable values.", expression));
+                    throw new InvalidOperationException(string.Format("An attempt to parse the variable symbol \"{0}\" appears to have resulted in a self referencing loop ({1}). Ensure that recursive loops do not exist in the variable values.", 
+                        expression, string.Join(" -> ", ancestor.symbolStack.Select(x => x.ToString()))));
                 }
                 ancestor = ancestor.parent;
             }


### PR DESCRIPTION
When a recursive-loop is encountered, add text to the Exception message showing the recursive variable path.

Previously the exception message was:
```
An attempt to parse the variable symbol "Foo" appears to have resulted in a self referencing loop. Ensure that recursive loops do not exist in the variable values.
```

Now it becomes:
```
An attempt to parse the variable symbol "Foo" appears to have resulted in a self referencing loop (Fix -> Fax -> Fox -> Foo). Ensure that recursive loops do not exist in the variable values.
```

Connects to https://github.com/OctopusDeploy/Issues/issues/2986