### PR TITLE
Added equality compares to `SymbolExpressionStep` and children. 

### DIFF
--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -217,6 +217,18 @@ namespace Octostache.Tests
         }
 
         [Fact]
+        public void MissingIndexedVariableWhenTheIndexerIsAValidVariableAndTheVariableNameIsTheSameAsTheIndexedVariableName()
+        {
+            var result = Evaluate("#{MY_VAR}", new Dictionary<string, string>
+            {
+                { "MY_VAR", "#{MY_VAR[#{foo}]}" },
+                { "foo", "bar" },
+            });
+            result.Should().Be("#{MY_VAR[#{foo}]}");
+        }
+
+
+        [Fact]
         public void IterationOverAnEmptyCollectionIsFine()
         {
             var result = Evaluate("Ok#{each nothing in missing}#{nothing}#{/each}", new Dictionary<string, string>());

--- a/source/Octostache/Templates/EvaluationContext.cs
+++ b/source/Octostache/Templates/EvaluationContext.cs
@@ -31,7 +31,7 @@ namespace Octostache.Templates
             return val.Item ?? "";
         }
 
-        private void ValidateNoRecursion(SymbolExpression expression)
+        private void ValidateThatRecursionIsNotOccuring(SymbolExpression expression)
         {
             var ancestor = this;
             while(ancestor != null)
@@ -61,7 +61,7 @@ namespace Octostache.Templates
 
         Binding WalkTo(SymbolExpression expression, out string[] missingTokens)
         {
-            ValidateNoRecursion(expression);
+            ValidateThatRecursionIsNotOccuring(expression);
             symbolStack.Push(expression);
 
             try

--- a/source/Octostache/Templates/Identifier.cs
+++ b/source/Octostache/Templates/Identifier.cs
@@ -2,21 +2,40 @@
 {
     class Identifier : SymbolExpressionStep
     {
-        readonly string text;
-
         public Identifier(string text)
         {
-            this.text = text;
+            Text = text;
         }
 
-        public string Text
-        {
-            get { return text; }
-        }
+        public string Text { get; }
 
         public override string ToString()
         {
             return Text;
+        }
+
+        public override bool Equals(SymbolExpressionStep other) => Equals(other as Identifier);
+
+
+        protected bool Equals(Identifier other)
+        {
+            return base.Equals(other) && string.Equals(Text, other.Text);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Identifier) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (base.GetHashCode() * 397) ^ (Text != null ? Text.GetHashCode() : 0);
+            }
         }
     }
 }

--- a/source/Octostache/Templates/Indexer.cs
+++ b/source/Octostache/Templates/Indexer.cs
@@ -22,5 +22,31 @@
         {
             return "[" + (IsSymbol ? "#{"+ Symbol +"}" : Index) + "]";
         }
+
+        public override bool Equals(SymbolExpressionStep other) => Equals(other as Indexer);
+
+        protected bool Equals(Indexer other)
+        {
+            return base.Equals(other) && string.Equals(Index, other.Index) && Equals(Symbol, other.Symbol);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Indexer) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Index != null ? Index.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Symbol != null ? Symbol.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/source/Octostache/Templates/SymbolExpressionStep.cs
+++ b/source/Octostache/Templates/SymbolExpressionStep.cs
@@ -1,4 +1,6 @@
-﻿using Sprache;
+﻿using System;
+using System.Collections;
+using Sprache;
 
 namespace Octostache.Templates
 {
@@ -9,5 +11,25 @@ namespace Octostache.Templates
     abstract class SymbolExpressionStep : IInputToken
     {
         public Position InputPosition { get; set; }
+
+        public virtual bool Equals(SymbolExpressionStep other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Equals(InputPosition, other.InputPosition);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((SymbolExpressionStep) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (InputPosition != null ? InputPosition.GetHashCode() : 0);
+        }
     }
 }


### PR DESCRIPTION
Without them `ValidateThatRecursionIsNotOccuring` was not detecting that the same symbol expression was already on the stack. Fixes https://github.com/OctopusDeploy/Issues/issues/3399