### PR TITLE
Adds parsing for escaped strings in conditionals in JSON

### DIFF
--- a/source/Octostache.Tests/JsonFixture.cs
+++ b/source/Octostache.Tests/JsonFixture.cs
@@ -104,6 +104,21 @@ namespace Octostache.Tests
             variables.Evaluate(pattern).Should().Be("Small:11.5,Large:15.21,");
         }
 
+
+        [Fact]
+        public void JsonEvaluatesConditionalsWithEscapes()
+        {
+            var variables = new VariableDictionary
+            {
+                ["Foo"] = "test text"
+            };
+
+            var pattern = "{\"Bar\":\"#{if Foo == \\\"test text\\\"}Blaa#{/if}\"}";
+
+            variables.Evaluate(pattern).Should().Be("{\"Bar\":\"Blaa\"}");
+        }
+
+
         [Fact]
         public void JsonObjectSupportsIteratorWithInnerSelection()
         {

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -179,7 +179,7 @@ namespace Octostache.Templates
         static readonly Parser<ConditionalExpressionToken> TokenMatch =
             (from expression in Symbol.Token()
              from _eq in Keyword("==").Token().Or(Keyword("!=").Token())
-             from compareTo in QuotedText.Token()
+             from compareTo in QuotedText.Token().Or(EscapedQuotedText.Token())
              let eq = _eq == "=="
              select new ConditionalStringExpressionToken(expression, eq, compareTo))
                 .WithPosition();
@@ -220,6 +220,11 @@ namespace Octostache.Templates
              from content in Parse.CharExcept(new[] { '"', '#' }).Many().Text()
              from close in Parse.Char('"')
              select content).Token();
+
+        public static readonly Parser<string> EscapedQuotedText =
+        (from open in Parse.String("\\\"")
+            from content in Parse.AnyChar.Until(Parse.String("\\\"")).Text()
+            select content).Token();
 
         static readonly Parser<TemplateToken> Token =
             Conditional.Select(t => (TemplateToken)t)


### PR DESCRIPTION
Previously, for a dictionary with

```
var variables = new VariableDictionary
{
    ["Var"] = "test text",
    ["Foo"] = "{\"Bar\":\"#{if Var == \\\"test text\\\"}Blaa#{/if}\"}"
};
```

then

```
variables.Evaluate("#{Foo.Bar}");
```

would have worked (because the JSON gets parsed before we apply TemplateParser), but

```
variables.Get("Foo");
```

wouldn't work (because we try to parse the escaped JSON directly with TemplateParser).  And this is how the JSON vars are used in Calamari.

This PR adds parsing to handle the escaped string in the JSON.  Nothing that used to parse should now fail.

Fixes OctopusDeploy/Issues#3213
Fixes #14