### PR TITLE
Short Circuit Evalatuation

### DIFF
--- a/source/Octostache/VariableDictionary.cs
+++ b/source/Octostache/VariableDictionary.cs
@@ -335,7 +335,7 @@ namespace Octostache
         /// <param name="expressionOrVariableOrText">The variable to evaluate</param>
         /// <returns>False if the variable contains something that looks like a substitution tokens, otherwise true</returns>
         public static bool CanEvaluationBeSkippedForExpression(string expressionOrVariableOrText)
-            => !expressionOrVariableOrText.Contains("#{");
+            => expressionOrVariableOrText == null || !expressionOrVariableOrText.Contains("#{");
 
     }
 }

--- a/source/Octostache/VariableDictionary.cs
+++ b/source/Octostache/VariableDictionary.cs
@@ -167,7 +167,7 @@ namespace Octostache
             error = null;
             if (expressionOrVariableOrText == null) return null;
 
-            if (!expressionOrVariableOrText.Contains("#{"))
+            if (CanEvaluationBeSkippedForExpression(expressionOrVariableOrText))
                 return expressionOrVariableOrText;
             
             Template template;
@@ -325,5 +325,17 @@ namespace Octostache
             return bindings.Select(b => b.Item).ToList();
 
         }
+
+        /// <summary>
+        /// Determines whether an expression/variable value/text needs to be evaluated before being used.
+        /// If true is returned from this method, the raw value of <paramref name="expressionOrVariableOrText" />
+        /// can be used without running it through a VariableDictionary. Even if false is returned, the value
+        /// may not contain subsitution tokens, and may be unchanged after evaluation. 
+        /// </summary>
+        /// <param name="expressionOrVariableOrText">The variable to evaluate</param>
+        /// <returns>False if the variable contains something that looks like a substitution tokens, otherwise true</returns>
+        public static bool CanEvaluationBeSkippedForExpression(string expressionOrVariableOrText)
+            => !expressionOrVariableOrText.Contains("#{");
+
     }
 }

--- a/source/Octostache/VariableDictionary.cs
+++ b/source/Octostache/VariableDictionary.cs
@@ -167,6 +167,9 @@ namespace Octostache
             error = null;
             if (expressionOrVariableOrText == null) return null;
 
+            if (!expressionOrVariableOrText.Contains("#{"))
+                return expressionOrVariableOrText;
+            
             Template template;
             if (!TemplateParser.TryParseTemplate(expressionOrVariableOrText, out template, out error, haltOnError))
                 return expressionOrVariableOrText;


### PR DESCRIPTION
If the expression to be evaluated doesn't contain a `#{`, then there isn't any point running it through the elevator... unless I am missing a case where Octostache does evaluation without `#{`.

This has a huge perf improvement when evaluating in a loop (eg 120sec -> 2 sec)