### PR TITLE
bug: non-existent property expression returns string "null"

### DIFF
--- a/source/Octostache.Tests/JsonFixture.cs
+++ b/source/Octostache.Tests/JsonFixture.cs
@@ -144,5 +144,18 @@ namespace Octostache.Tests
 
             variables.Evaluate(pattern).Should().Be("Alphabet");
         }
+
+        [Fact]
+        public void MissingJsonPropertyTreatedAsEmptyString()
+        {
+            var variables = new VariableDictionary
+            {
+                ["Foo"] = "{Bar: \"ABC\"}",
+            };
+
+            var pattern = @"Alpha#{Foo.NotBar}bet";
+
+            variables.Evaluate(pattern).Should().Be("Alphabet");
+        }
     }
 }

--- a/source/Octostache/CustomStringParsers/JsonParser.cs
+++ b/source/Octostache/CustomStringParsers/JsonParser.cs
@@ -114,6 +114,10 @@ namespace Octostache.CustomStringParsers
 
         static Binding ConvertJTokenToBinding(JToken token)
         {
+            if(token == null)
+            {
+                return new Binding(string.Empty);
+            }
             if (token is JValue)
             {
                 return new Binding(token.Value<string>() ?? string.Empty);


### PR DESCRIPTION
Fixed a bug when expression referring to non-existing json object property would return non-empty string. It returns empty string now. Unit test included