### PR TITLE
Add a more appropriately named markdown to html function

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -68,28 +68,34 @@ namespace Octostache.Tests
             result.Should().Be(expectedResult);
         }
 
-        [Fact]
-        public void MarkdownIsProcessed()
+        [Theory]
+        [InlineData("#{Foo | Markdown}")]
+        [InlineData("#{Foo | ToHtml}")]
+        public void MarkdownIsProcessed(string input)
         {
-            var result = Evaluate("#{Foo | Markdown}", new Dictionary<string, string> { { "Foo", "_yeah!_" } });
+            var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "_yeah!_" } });
             result.Trim().Should().Be("<p><em>yeah!</em></p>");
         }
 
-        [Fact]
-        public void MarkdownHttpLinkIsProcessed()
+        [Theory]
+        [InlineData("#{Foo | Markdown}")]
+        [InlineData("#{Foo | ToHtml}")]
+        public void MarkdownHttpLinkIsProcessed(string input)
         {
-            var result = Evaluate("#{Foo | Markdown}", new Dictionary<string, string> { { "Foo", "http://octopus.com" } });
+            var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "http://octopus.com" } });
             result.Trim().Should().Be("<p><a href=\"http://octopus.com\">http://octopus.com</a></p>");
         }
 
-        [Fact]
-        public void MarkdownTablesAreProcessed()
+        [Theory]
+        [InlineData("#{Foo | Markdown}")]
+        [InlineData("#{Foo | ToHtml}")]
+        public void MarkdownTablesAreProcessed(string input)
         {
             var dictionary = new Dictionary<string, string> { {"Foo", 
 @"|Header1|Header2|
 |-|-|
 |Cell1|Cell2|" }};
-            var result = Evaluate("#{Foo | Markdown}", dictionary);
+            var result = Evaluate(input, dictionary);
             result.Trim().Should().Be("<table>\n<thead>\n<tr>\n<th>Header1</th>\n<th>Header2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Cell1</td>\n<td>Cell2</td>\n</tr>\n</tbody>\n</table>");
         }
 

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -79,12 +79,14 @@ namespace Octostache.Tests
         }
 
         [Theory]
-        [InlineData("#{Foo | Markdown}")]
-        [InlineData("#{Foo | MarkdownToHtml}")]
-        public void MarkdownHttpLinkIsProcessed(string input)
+        [InlineData("#{Foo | Markdown}", "http://octopus.com", "<p><a href=\"http://octopus.com\">http://octopus.com</a></p>")]
+        [InlineData("#{Foo | MarkdownToHtml}", "http://octopus.com", "<p><a href=\"http://octopus.com\">http://octopus.com</a></p>")]
+        [InlineData("#{Foo | Markdown}", "[Some link](http://octopus.com)", "<p><a href=\"http://octopus.com\">Some link</a></p>")]
+        [InlineData("#{Foo | MarkdownToHtml}", "[Some link](http://octopus.com)", "<p><a href=\"http://octopus.com\">Some link</a></p>")]
+        public void MarkdownHttpLinkIsProcessed(string input, string value, string expectedResult)
         {
-            var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "http://octopus.com" } });
-            result.Trim().Should().Be("<p><a href=\"http://octopus.com\">http://octopus.com</a></p>");
+            var result = Evaluate(input, new Dictionary<string, string> { { "Foo", value } });
+            result.Trim().Should().Be(expectedResult);
         }
 
         [Theory]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -13,6 +13,7 @@ namespace Octostache.Tests
         [InlineData("#{Foo.Bar | HtmlEscape}")]
         [InlineData("#{Foo.Bar | ToUpper}")]
         [InlineData("#{Foo.Bar | Markdown}")]
+        [InlineData("#{Foo.Bar | MarkdownToHtml}")]
         public void UnmatchedSubstitutionsAreEchoed(string template)
         {
             string error;
@@ -70,7 +71,7 @@ namespace Octostache.Tests
 
         [Theory]
         [InlineData("#{Foo | Markdown}")]
-        [InlineData("#{Foo | ToHtml}")]
+        [InlineData("#{Foo | MarkdownToHtml}")]
         public void MarkdownIsProcessed(string input)
         {
             var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "_yeah!_" } });
@@ -79,7 +80,7 @@ namespace Octostache.Tests
 
         [Theory]
         [InlineData("#{Foo | Markdown}")]
-        [InlineData("#{Foo | ToHtml}")]
+        [InlineData("#{Foo | MarkdownToHtml}")]
         public void MarkdownHttpLinkIsProcessed(string input)
         {
             var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "http://octopus.com" } });
@@ -88,7 +89,7 @@ namespace Octostache.Tests
 
         [Theory]
         [InlineData("#{Foo | Markdown}")]
-        [InlineData("#{Foo | ToHtml}")]
+        [InlineData("#{Foo | MarkdownToHtml}")]
         public void MarkdownTablesAreProcessed(string input)
         {
             var dictionary = new Dictionary<string, string> { {"Foo", 

--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -14,14 +14,15 @@ namespace Octostache.Templates
             {"htmlescape", TextEscapeFunction.HtmlEscape },
             {"xmlescape", TextEscapeFunction.XmlEscape },
             {"jsonescape", TextEscapeFunction.JsonEscape },
-            {"markdown", TextEscapeFunction.Markdown },
+            {"markdown", TextEscapeFunction.MarkdownToHtml },
+            {"markdowntohtml", TextEscapeFunction.MarkdownToHtml },
             {"nowdate", DateFunction.NowDate },
             {"nowdateutc", DateFunction.NowDateUtc },
             {"format", FormatFunction.Format },
             {"replace", TextReplaceFunction.Replace }
         };
  
-        // Configuration shoudl be done at startup, this isn't thread-safe.
+        // Configuration should be done at startup, this isn't thread-safe.
         public static void Register(string name, Func<string, string[], string> implementation)
         {
             var functionName = name.ToLowerInvariant();

--- a/source/Octostache/Templates/Functions/TextEscapeFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEscapeFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Markdig;
@@ -32,7 +33,13 @@ namespace Octostache.Templates.Functions
             return Escape(argument, JsonEntityMap);
         }
 
+        [Obsolete("Please use MarkdownToHtml instead.")]
         public static string Markdown(string argument, string[] options)
+        {
+            return MarkdownToHtml(argument, options);
+        }
+
+        public static string MarkdownToHtml(string argument, string[] options)
         {
             if (argument == null || options.Any())
                 return null;


### PR DESCRIPTION
Mark old method as obsolete.