### PR TITLE
Throw a specific exception if a recursive loop is defined

### DIFF
--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Octostache.Templates;
 using Xunit;
 
 namespace Octostache.Tests
@@ -115,13 +116,13 @@ namespace Octostache.Tests
         }
 
         [Theory]
-        [InlineData("#{Foo}", "Foo=#{Foo}")]
-        [InlineData("#{Foo}", "Foo=#{Fox};Fox=#{Fax};Fax=#{Fix};Fix=#{Foo}")]
-        public void MaximumRecursionLimitException(string template, string variableDefinitions)
+        [InlineData("#{Foo}", "Foo=#{Foo}", "Foo -> Foo")]
+        [InlineData("#{Foo}", "Foo=#{Fox};Fox=#{Fax};Fax=#{Fix};Fix=#{Foo}", "Foo -> Fox -> Fax -> Fix -> Foo")]
+        public void MaximumRecursionLimitException(string template, string variableDefinitions, string expectedChain)
         {
             var ex =
-                Assert.Throws<InvalidOperationException>(() => ParseVariables(variableDefinitions).Evaluate(template));
-            ex.Message.Should().Contain("appears to have resulted in a self referencing loop");
+                Assert.Throws<RecursiveDefinitionException>(() => ParseVariables(variableDefinitions).Evaluate(template));
+            ex.Message.Should().Be($"An attempt to parse the variable symbol \"Foo\" appears to have resulted in a self referencing loop ({expectedChain}). Ensure that recursive loops do not exist in the variable values.");
         }
 
         [Fact]

--- a/source/Octostache/Templates/EvaluationContext.cs
+++ b/source/Octostache/Templates/EvaluationContext.cs
@@ -38,8 +38,7 @@ namespace Octostache.Templates
             {
                 if (ancestor.symbolStack.Contains(expression, SymbolExpression.StepsComparer))
                 {
-                    throw new InvalidOperationException(string.Format("An attempt to parse the variable symbol \"{0}\" appears to have resulted in a self referencing loop ({1}). Ensure that recursive loops do not exist in the variable values.", 
-                        expression, string.Join(" -> ", ancestor.symbolStack.Select(x => x.ToString()))));
+                    throw new RecursiveDefinitionException(expression, ancestor.symbolStack);
                 }
                 ancestor = ancestor.parent;
             }

--- a/source/Octostache/Templates/RecursiveDefinitionException.cs
+++ b/source/Octostache/Templates/RecursiveDefinitionException.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octostache.Templates
+{
+    public class RecursiveDefinitionException : InvalidOperationException
+    {
+        internal RecursiveDefinitionException(SymbolExpression symbol, Stack<SymbolExpression> ancestorSymbolStack)
+            : base ($"An attempt to parse the variable symbol \"{symbol}\" appears to have resulted in a self referencing " +
+                    $"loop ({string.Join(" -> ", ancestorSymbolStack.Reverse().Select(x => x.ToString()))} -> {symbol}). " +
+                    $"Ensure that recursive loops do not exist in the variable values.")
+        {
+        }
+    }
+}


### PR DESCRIPTION
So we can handle and upstream and not log the stack trace.

Relates to https://github.com/OctopusDeploy/Issues/issues/5642
Relates to https://github.com/OctopusDeploy/Calamari/pull/406