### PR TITLE
Added Ability to encrypt variables with RSA Certificate.

### DIFF
--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -26,7 +26,8 @@ namespace Octostache.Templates
             {"substring", TextSubstringFunction.Substring},
             {"truncate", TextManipulationFunction.Truncate},
             {"trim", TextManipulationFunction.Trim},
-            {"uripart", TextManipulationFunction.UriPart}
+            {"uripart", TextManipulationFunction.UriPart},
+            {"rsaencrypt", TextEncryptFunction.RSAEncrypt }
         };
 
         // Configuration should be done at startup, this isn't thread-safe.

--- a/source/Octostache/Templates/Functions/TextEncryptFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEncryptFunction.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Octostache.Templates.Functions
+{
+    internal class TextEncryptFunction
+    {
+        public static string RSAEncrypt(string data, string[] arguments)
+        {
+            if (arguments == null || arguments.Length == 0 || arguments.Length > 2)
+            {
+                return null;
+            }
+
+            try
+            {
+
+                var certificate = new X509Certificate2(Convert.FromBase64String(arguments[0]));
+#if NET40
+                var publicKey = (RSACryptoServiceProvider)certificate.PublicKey.Key;
+#else
+                var publicKey = certificate.GetRSAPublicKey();
+#endif
+                using (publicKey)
+                {
+                    var encoding = Encoding.GetEncoding(arguments.Length > 1 ? arguments[1] : "utf-8");
+                    var byteData = encoding.GetBytes(data);
+#if NET40
+                    var encryptedBytes = publicKey.Encrypt(byteData, false);
+#else
+                    var encryptedBytes = publicKey.Encrypt(byteData, RSAEncryptionPadding.OaepSHA1);
+#endif
+                    return Convert.ToBase64String(encryptedBytes);
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/source/Octostache/Templates/Functions/TextEncryptFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEncryptFunction.cs
@@ -14,10 +14,12 @@ namespace Octostache.Templates.Functions
                 return null;
             }
 
+            X509Certificate2 certificate = null;
+
             try
             {
 
-                var certificate = new X509Certificate2(Convert.FromBase64String(arguments[0]));
+                certificate = new X509Certificate2(Convert.FromBase64String(arguments[0]));
 #if NET40
                 var publicKey = (RSACryptoServiceProvider)certificate.PublicKey.Key;
 #else
@@ -37,6 +39,14 @@ namespace Octostache.Templates.Functions
             }
             catch (Exception)
             {
+            }
+            finally
+            {
+                // IDisposable was only added to certificate after.Net 4.6
+                if (certificate != null && certificate is IDisposable disposableCertificate)
+                {
+                    disposableCertificate.Dispose();
+                }
             }
 
             return null;

--- a/source/Octostache/Templates/Functions/TextEncryptFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEncryptFunction.cs
@@ -28,7 +28,7 @@ namespace Octostache.Templates.Functions
                     var encoding = Encoding.GetEncoding(arguments.Length > 1 ? arguments[1] : "utf-8");
                     var byteData = encoding.GetBytes(data);
 #if NET40
-                    var encryptedBytes = publicKey.Encrypt(byteData, false);
+                    var encryptedBytes = publicKey.Encrypt(byteData, true);
 #else
                     var encryptedBytes = publicKey.Encrypt(byteData, RSAEncryptionPadding.OaepSHA1);
 #endif


### PR DESCRIPTION
Was curious to see if this feature was a viable option to consider adding? 

We do this type of thing manually right now with variables that store the encrypted text and it is a pain when updating certificates.

I can flush out the .Net Framework 4.5.2 tests plus additional test cases if needed.