### PR TITLE
Add filters for escaping variables in YAML

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -205,14 +205,6 @@ namespace Octostache.Tests
             result.Trim().Should().Be("<p><em>yeah!</em></p>");
         }
 
-        [Fact]
-        public void Test()
-        {
-            var input = "a\r\nb\nc\na";
-            var parts = input.Split('\n').Distinct();
-            
-        }
-        
         [Theory]
         [InlineData("#{Foo | Markdown}", "http://octopus.com", "<p><a href=\"http://octopus.com\">http://octopus.com</a></p>")]
         [InlineData("#{Foo | MarkdownToHtml}", "http://octopus.com", "<p><a href=\"http://octopus.com\">http://octopus.com</a></p>")]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -96,7 +96,7 @@ namespace Octostache.Tests
         [InlineData("single'quote", "single''quote")]
         [InlineData("\\'", "\\''")]
         [InlineData("a\n\tb\n\tc\n\td", "a\n\n\tb\n\n\tc\n\n\td")]
-        [InlineData("a\r\nb", "a\r\n\r\nb")]
+        [InlineData("a\r\nb", "a\n\nb")]
         [InlineData("", "")]
         [InlineData(null, "")]
         public void YamlSingleQuoteIsEscaped(string input, string expectedResult)

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -175,7 +175,8 @@ namespace Octostache.Tests
         [InlineData("\r\n", "\r\n")]
         [InlineData("\r\n\r\n", "\r\n\r\n")]
         [InlineData("a\nb", "a\nb")]
-        [InlineData("a \nb", "a\nb")]
+        [InlineData("a \nb", "a\nb")] // white space before a newline: cannot be escaped within single quotes
+        [InlineData("a\n b", "a\nb")] // white space after a newline: cannot be escaped within single quotes
         [InlineData("a\n\nb", "a\n\nb")]
         [InlineData("a\r\nb", "a\r\nb")]
         [InlineData("a\r\n\nb", "a\r\n\nb")]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -90,6 +90,24 @@ namespace Octostache.Tests
             var result = Evaluate("#{Foo | JsonEscape}", new Dictionary<string, string> { { "Foo", input } });
             result.Should().Be(expectedResult);
         }
+        
+        [Theory]
+        [InlineData("single'quote", "single''quote")]
+        [InlineData("\\'", "\\'")]
+        [InlineData("a\n\tb\n\tc\n\td", "a\n\tb\n\tc\n\td")]
+        public void YamlSingleQuoteIsEscaped(string input, string expectedResult)
+        {
+            var result = Evaluate("#{Foo | YamlSingleQuoteEscape}", new Dictionary<string, string>({ { "Foo", input } });
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData("double\"quote", "double\"\"quote")]
+        public void YamlDoubleQuoteIsEscaped(string input, string expectedResult)
+        {
+            var result = Evaluate("#{Foo | YamlDoubleQuoteEscape}", new Dictionary<string, string>({ { "Foo", input } });
+            result.Should().Be(expectedResult);
+        }
 
         [Theory]
         [InlineData("#{Foo | Markdown}")]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -150,6 +150,47 @@ namespace Octostache.Tests
         }
 
         [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("\"")]
+        [InlineData("'")]
+        [InlineData("\t")]
+        [InlineData("\n")]
+        [InlineData("我叫章鱼")]
+        [InlineData("this contains six spaces\nand one line break")]
+        public void YamlSingleQuotedStringsCanRoundTrip(string input)
+        {
+            var yaml = Evaluate("Key: '#{Input | YamlSingleQuoteEscape}'", new Dictionary<string, string> { { "Input", input } });
+
+            var doc = new DeserializerBuilder()
+                .Build()
+                .Deserialize<TestDocument>(yaml);
+
+            doc.Key.Should().Be(input);
+        }
+
+        [Theory]
+        [InlineData("\r\n", "\n")]
+        [InlineData("a\nb", "a\nb")]
+        [InlineData("a \nb", "a\nb")]
+        [InlineData("a\n\nb", "a\n\nb")]
+        [InlineData("a\r\nb", "a\nb")]
+        [InlineData("a\r\n\nb", "a\n\nb")]
+        [InlineData("a \n\nb", "a\n\nb")]
+        [InlineData("a\n\n\n\n\nb", "a\n\n\n\n\nb")]
+        [InlineData("this contains six spaces\nand one line break", "this contains six spaces\nand one line break")]
+        public void YamlSingleQuotedStringsCanRoundTripWithSideEffects(string input, string expected)
+        {
+            var yaml = Evaluate("Key: '#{Input | YamlSingleQuoteEscape}'", new Dictionary<string, string> { { "Input", input } });
+
+            var doc = new DeserializerBuilder()
+                .Build()
+                .Deserialize<TestDocument>(yaml);
+
+            doc.Key.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("#{Foo | Markdown}")]
         [InlineData("#{Foo | MarkdownToHtml}")]
         public void MarkdownIsProcessed(string input)

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -95,6 +95,7 @@ namespace Octostache.Tests
         [InlineData("single'quote", "single''quote")]
         [InlineData("\\'", "\\''")]
         [InlineData("a\n\tb\n\tc\n\td", "a\n\tb\n\tc\n\td")]
+        [InlineData(null, "")]
         public void YamlSingleQuoteIsEscaped(string input, string expectedResult)
         {
             var result = Evaluate("#{Foo | YamlSingleQuoteEscape}", new Dictionary<string, string> { { "Foo", input } });
@@ -105,6 +106,7 @@ namespace Octostache.Tests
         [InlineData("double\"quote", "double\\\"quote")]
         [InlineData("\\", "\\\\")]
         [InlineData("single'quote", "single'quote")]
+        [InlineData(null, "")]
         public void YamlDoubleQuoteIsEscaped(string input, string expectedResult)
         {
             var result = Evaluate("#{Foo | YamlDoubleQuoteEscape}", new Dictionary<string, string> { { "Foo", input } });

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -93,19 +93,21 @@ namespace Octostache.Tests
         
         [Theory]
         [InlineData("single'quote", "single''quote")]
-        [InlineData("\\'", "\\'")]
+        [InlineData("\\'", "\\''")]
         [InlineData("a\n\tb\n\tc\n\td", "a\n\tb\n\tc\n\td")]
         public void YamlSingleQuoteIsEscaped(string input, string expectedResult)
         {
-            var result = Evaluate("#{Foo | YamlSingleQuoteEscape}", new Dictionary<string, string>({ { "Foo", input } });
+            var result = Evaluate("#{Foo | YamlSingleQuoteEscape}", new Dictionary<string, string> { { "Foo", input } });
             result.Should().Be(expectedResult);
         }
 
         [Theory]
-        [InlineData("double\"quote", "double\"\"quote")]
+        [InlineData("double\"quote", "double\\\"quote")]
+        [InlineData("\\", "\\\\")]
+        [InlineData("single'quote", "single'quote")]
         public void YamlDoubleQuoteIsEscaped(string input, string expectedResult)
         {
-            var result = Evaluate("#{Foo | YamlDoubleQuoteEscape}", new Dictionary<string, string>({ { "Foo", input } });
+            var result = Evaluate("#{Foo | YamlDoubleQuoteEscape}", new Dictionary<string, string> { { "Foo", input } });
             result.Should().Be(expectedResult);
         }
 

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Xunit;
 using FluentAssertions;
@@ -94,7 +94,9 @@ namespace Octostache.Tests
         [Theory]
         [InlineData("single'quote", "single''quote")]
         [InlineData("\\'", "\\''")]
-        [InlineData("a\n\tb\n\tc\n\td", "a\n\tb\n\tc\n\td")]
+        [InlineData("a\n\tb\n\tc\n\td", "a\n\n\tb\n\n\tc\n\n\td")]
+        [InlineData("a\r\nb", "a\r\n\r\nb")]
+        [InlineData("", "")]
         [InlineData(null, "")]
         public void YamlSingleQuoteIsEscaped(string input, string expectedResult)
         {

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Sprache" Version="2.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -17,6 +17,8 @@ namespace Octostache.Templates
             {"uridataescape", TextEscapeFunction.UriDataStringEscape},
             {"xmlescape", TextEscapeFunction.XmlEscape },
             {"jsonescape", TextEscapeFunction.JsonEscape },
+            {"yamlsinglequoteescape", TextEscapeFunction.YamlSingleQuoteEscape },
+            {"yamldoublequoteescape", TextEscapeFunction.YamlDoubleQuoteEscape },
             {"markdown", TextEscapeFunction.MarkdownToHtml },
             {"markdowntohtml", TextEscapeFunction.MarkdownToHtml },
             {"nowdate", DateFunction.NowDate },

--- a/source/Octostache/Templates/Functions/TextEscapeFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEscapeFunction.cs
@@ -54,7 +54,7 @@ namespace Octostache.Templates.Functions
             return Escape(argument, YamlDoubleQuoteMap);
         }
 
-        private static readonly Regex NewLineRegex = new Regex(@"\n+");
+        private static readonly Regex NewLineRegex = new Regex(@"(?:\r?\n)+");
         
         private static string HandleSingleQuoteYamlNewLines(string input)
         {
@@ -63,11 +63,14 @@ namespace Octostache.Templates.Functions
             // A triple newline is parsed by YAML as a double newline
             // ...etc
 
-            // YAML also turns CRLFs inside a scalar into LFs
-            // https://yaml.org/spec/history/2002-10-31.html#syntax-eol-norm
+            var output = NewLineRegex.Replace(input, m =>
+            {
+                var newlineToInsert = m.Value.StartsWith("\r")
+                    ? "\r\n"
+                    : "\n";
 
-            var output = input.Replace("\r\n", "\n");
-            output = NewLineRegex.Replace(output, m => new string('\n', m.Length + 1));
+                return newlineToInsert + m.Value;
+            });
 
             return output;
         }

--- a/source/Octostache/Templates/Functions/TextEscapeFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEscapeFunction.cs
@@ -34,6 +34,22 @@ namespace Octostache.Templates.Functions
             return Escape(argument, JsonEntityMap);
         }
 
+        public static string YamlSingleQuoteEscape(string argument, string[] options)
+        {
+            if (options.Any())
+                return null;
+
+            return Escape(argument, YamlSingleQuoteMap);
+        }
+
+        public static string YamlDoubleQuoteEscape(string argument, string[] options)
+        {
+            if (options.Any())
+                return null;
+
+            return Escape(argument, YamlDoubleQuoteMap);
+        }
+
         [Obsolete("Please use MarkdownToHtml instead.")]
         public static string Markdown(string argument, string[] options)
         {
@@ -116,6 +132,17 @@ namespace Octostache.Templates.Functions
             { '\t', @"\t" },
             { '\n', @"\n" },
             { '\\', @"\\" }
+        };
+        
+        static readonly IDictionary<char, string> YamlSingleQuoteMap = new Dictionary<char, string>
+        {
+            { '\'', "''"}
+        };
+        
+        static readonly IDictionary<char, string> YamlDoubleQuoteMap = new Dictionary<char, string>
+        {
+            { '\\', "\\\\"},
+            { '"', "\\\""}
         };
     }
 }

--- a/source/Octostache/Templates/Functions/TextEscapeFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEscapeFunction.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using Markdig;
 
 namespace Octostache.Templates.Functions
@@ -36,9 +37,11 @@ namespace Octostache.Templates.Functions
 
         public static string YamlSingleQuoteEscape(string argument, string[] options)
         {
-            if (options.Any())
+            if (argument == null || options.Any())
                 return null;
 
+            argument = ReplaceNewLinesWithDoubleNewLines(argument);
+            
             return Escape(argument, YamlSingleQuoteMap);
         }
 
@@ -50,6 +53,13 @@ namespace Octostache.Templates.Functions
             return Escape(argument, YamlDoubleQuoteMap);
         }
 
+        private static readonly Regex NewLineRegex = new Regex(@"\r?\n");
+        
+        private static string ReplaceNewLinesWithDoubleNewLines(string input)
+        {
+            return NewLineRegex.Replace(input, "$0$0");
+        }
+        
         [Obsolete("Please use MarkdownToHtml instead.")]
         public static string Markdown(string argument, string[] options)
         {
@@ -136,7 +146,7 @@ namespace Octostache.Templates.Functions
         
         static readonly IDictionary<char, string> YamlSingleQuoteMap = new Dictionary<char, string>
         {
-            { '\'', "''"}
+            { '\'', "''" }
         };
         
         static readonly IDictionary<char, string> YamlDoubleQuoteMap = new Dictionary<char, string>

--- a/source/Octostache/Templates/Functions/TextEscapeFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEscapeFunction.cs
@@ -54,7 +54,7 @@ namespace Octostache.Templates.Functions
             return Escape(argument, YamlDoubleQuoteMap);
         }
 
-        private static readonly Regex NewLineRegex = new Regex(@"(?:\r?\n)+");
+        private static readonly Regex NewLineRegex = new Regex(@"(?:\r?\n)+", RegexOptions.Compiled);
         
         private static string HandleSingleQuoteYamlNewLines(string input)
         {


### PR DESCRIPTION
This PR adds two new filters for escaping variables in yaml:

- `YamlSingleQuoteEscape`
- `YamlDoubleQuoteEscape`

How to review this PR:

- Code quality
- Do we have enough test cases? Are there any edge cases to consider?
- Do we need any other filters?