### PR TITLE
Accept an optional TimeZoneId as an argument to NowDate

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -354,6 +354,23 @@ namespace Octostache.Tests
         }
 
         [Fact]
+        public void NowDateAcceptsTimeZoneId()
+        {
+            var result = Evaluate("#{ | NowDate \\\"Eastern Standard Time\\\"}", new Dictionary<string, string>());
+            DateTime.Parse(result).Should().BeCloseTo(TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Now, "Eastern Standard Time"), 60000);
+        }
+
+        [Fact]
+        public void NowDateAcceptsFormatAndTimeZoneId()
+        {
+            var result = Evaluate("#{ | NowDate \\\"Eastern Standard Time\\\" \\\"MM/dd/yy H:mm:ss zzz\\\"}", new Dictionary<string, string>());
+            DateTime.Parse(result).Should().BeCloseTo(TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Now, "Eastern Standard Time"), 60000);
+
+            var result1 = Evaluate("#{ | NowDate \\\"MM/dd/yy H:mm:ss zzz\\\" \\\"Eastern Standard Time\\\"}", new Dictionary<string, string>());
+            DateTime.Parse(result1).Should().BeCloseTo(TimeZoneInfo.ConvertTimeBySystemTimeZoneId(DateTime.Now, "Eastern Standard Time"), 60000);
+        }
+
+        [Fact]
         public void NullJsonPropertyTreatedAsEmptyString()
         {
             var result = Evaluate("Alpha#{Foo.Bar | ToUpper}bet", new Dictionary<string, string> { { "Foo", "{Bar: null}" } });

--- a/source/Octostache/Templates/Functions/DateFunction.cs
+++ b/source/Octostache/Templates/Functions/DateFunction.cs
@@ -7,10 +7,26 @@ namespace Octostache.Templates.Functions
     {
         public static string? NowDate(string? argument, string[] options)
         {
-            if (argument != null || options.Length > 1)
+            if (argument != null || options.Length > 2)
                 return null;
 
-            return DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified).ToString(options.Any() ? options[0] : "O");
+            string? formatString = null;
+            TimeZoneInfo? tz = null;
+
+            foreach (var option in options)
+            {
+                try
+                {
+                    tz = TimeZoneInfo.FindSystemTimeZoneById(option);
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                    formatString = option;
+                }
+            }
+
+            var dt = (tz == null) ? DateTime.Now : TimeZoneInfo.ConvertTime(DateTime.Now, tz);
+            return dt.ToString(formatString ?? "O");
         }
 
         public static string? NowDateUtc(string? argument, string[] options)


### PR DESCRIPTION
This is a very naïve attempt to give users the ability to customize the timezone when using the `NowDate` filter. I had a customer request this feature for use with the Email notification step - https://octopus.zendesk.com/agent/tickets/64730
And we had some brief discussion in Slack: https://octopusdeploy.slack.com/archives/C033W4273/p1612912152089000

I'm opening this as a draft primarily to help drive discussion. I'm pretty sure that this implementation would break down and not work for chained constructions like:
```
#{ | NowDate "Eastern Standard Time" | Format Date "MM/dd/yy H:mm:ss"}
```
where the `Format Date` filter is not aware that the previous string was based on some non system local time zone.
As far as I can tell, there doesn't appear to be any kind of state or passed context for the entire expression where something like this timezone could live and be referenced, and doing something like that feels like a substantial change to the library.

Interested to hear people's thoughts. Thanks!
