### PR TITLE
Add hash filters

### DIFF
--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -42,7 +42,14 @@ namespace Octostache.Templates
             { "versionprereleaseprefix", VersionParseFunction.VersionReleasePrefix },
             { "versionprereleasecounter", VersionParseFunction.VersionReleaseCounter },
             { "versionrevision", VersionParseFunction.VersionRevision },
-            { "versionmetadata", VersionParseFunction.VersionMetadata }
+            { "versionmetadata", VersionParseFunction.VersionMetadata },
+            { "append", TextManipulationFunction.Append },
+            { "prepend", TextManipulationFunction.Prepend },
+            { "md5", HashFunction.Md5 },
+            { "sha1", HashFunction.Sha1 },
+            { "sha256", HashFunction.Sha256 },
+            { "sha384", HashFunction.Sha384 },
+            { "sha512", HashFunction.Sha512 },
         };
 
         public static string? InvokeOrNull(string function, string? argument, string[] options)

--- a/source/Octostache/Templates/Functions/HashFunction.cs
+++ b/source/Octostache/Templates/Functions/HashFunction.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Octostache.Templates.Functions
+{
+    static class HashFunction
+    {
+        public static string? Md5(string? argument, string[] options)
+        {
+            return CalculateHash(MD5.Create, argument, options);
+        }
+
+        public static string? Sha1(string? argument, string[] options)
+        {
+            return CalculateHash(SHA1.Create, argument, options);
+        }
+
+        public static string? Sha256(string? argument, string[] options)
+        {
+            return CalculateHash(SHA256.Create, argument, options);
+        }
+
+        public static string? Sha384(string? argument, string[] options)
+        {
+            return CalculateHash(SHA384.Create, argument, options);
+        }
+
+        public static string? Sha512(string? argument, string[] options)
+        {
+            return CalculateHash(SHA512.Create, argument, options);
+        }
+
+        static string? CalculateHash(Func<HashAlgorithm> algorithm, string? argument, string[] options)
+        {
+            if (argument == null)
+            {
+                return null;
+            }
+
+            var hashOptions = new HashOptions(options);
+            if (!hashOptions.IsValid)
+            {
+                return null;
+            }
+
+            try
+            {
+                var argumentBytes = hashOptions.GetBytes(argument);
+
+                var hsh = algorithm();
+                return HexDigest(hsh.ComputeHash(argumentBytes), hashOptions);
+            }
+            catch
+            {
+                // Likely invalid input
+                return null;
+            }
+        }
+
+        static string HexDigest(byte[] bytes, HashOptions options)
+        {
+            var size = options.DigestSize.GetValueOrDefault(bytes.Length);
+            if (size > bytes.Length)
+            {
+                size = bytes.Length;
+            }
+            var sb = new StringBuilder(size * 2);
+
+            for (var i = 0; i < size; i++)
+            {
+                sb.Append(bytes[i].ToString("x2"));
+            }
+
+            return sb.ToString();
+        }
+
+        class HashOptions
+        {
+            public HashOptions(string[] options)
+            {
+                if (options.Length == 0)
+                {
+                    return;
+                }
+                if (options.Length > 2)
+                {
+                    IsValid = false;
+                    return;
+                }
+
+                if (int.TryParse(options[0], out var size) && size > 0)
+                {
+                    DigestSize = size;
+                    if (options.Length > 1)
+                    {
+                        var encoding = GetEncoding(options[1]);
+                        if (encoding == null)
+                        {
+                            IsValid = false;
+                        }
+                        else
+                        {
+                            GetBytes = encoding;
+                        }
+                    }
+                }
+                else
+                {
+                    var encoding = GetEncoding(options[0]);
+                    if (encoding == null)
+                    {
+                        IsValid = false;
+                    }
+                    else
+                    {
+                        GetBytes = encoding;
+                    }
+
+                    if (IsValid && options.Length > 1)
+                    {
+                        if (int.TryParse(options[1], out size) && size > 0)
+                        {
+                            DigestSize = size;
+                        }
+                        else
+                        {
+                            IsValid = false;
+                        }
+                    }
+                }
+            }
+
+            public Func<string, byte[]> GetBytes { get; } = Encoding.UTF8.GetBytes;
+            public int? DigestSize { get; }
+
+            public bool IsValid { get; } = true;
+
+            static Func<string, byte[]>? GetEncoding(string encoding)
+            {
+                switch (encoding.ToLowerInvariant())
+                {
+                    case "base64":
+                        return Convert.FromBase64String;
+                    case "utf8":
+                    case "utf-8":
+                        return Encoding.UTF8.GetBytes;
+                    case "unicode":
+                        return Encoding.Unicode.GetBytes;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/source/Octostache/Templates/Functions/TextManipulationFunction.cs
+++ b/source/Octostache/Templates/Functions/TextManipulationFunction.cs
@@ -66,6 +66,44 @@ namespace Octostache.Templates.Functions
             }
         }
 
+        public static string? Append(string? argument, string[] options)
+        {
+            if (argument == null)
+            {
+                if (!options.Any())
+                {
+                    return null;
+                }
+
+                return string.Concat(options);
+            }
+            else if (!options.Any())
+            {
+                return null;
+            }
+
+            return argument + string.Concat(options);
+        }
+
+        public static string? Prepend(string? argument, string[] options)
+        {
+            if (argument == null)
+            {
+                if (!options.Any())
+                {
+                    return null;
+                }
+
+                return string.Concat(options);
+            }
+            else if (!options.Any())
+            {
+                return null;
+            }
+
+            return string.Concat(options) + argument;
+        }
+
         public static string? Truncate(string? argument, string[] options)
         {
             if (argument == null ||


### PR DESCRIPTION
To support running a hash across multiple values, the Append and Prepend
filters were also added. They can be used to build up a string from
variables or fixed text.

They also provide a convenient way to send a hard-coded value to a
filter. E.g.

```
  #{ | Append "Hello World" | Md5 }
```

Common hash functions have been added:
- Md5
- Sha1
- Sha256
- Sha384
- Sha512

Each of these take 0-2 parameters.

- With no options, the filter will output the hex digest of the
  resulting hash.
- With an integer greater than zero, truncates the hash to the specified
  number of bytes. The total characters will be twice this number as
  each byte in the hash is represented by two characters in the hex
  representation.
- With an encoding of either 'utf8', 'utf-8', 'unicode' or 'base64'. For
  'utf8' and 'unicode' the string will be encoded in the applicable
  encoding before calculating the hash. For 'base64', the string is
  treated as a base64 encoded string and the hash is made of the
  underlying binary data.
- With two parameters, both the size in bytes and encoding can be
  specified. These can be specified in any order.