### PR TITLE
Add indent filter

### DIFF
--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -34,6 +34,7 @@ namespace Octostache.Templates
             { "substring", TextSubstringFunction.Substring },
             { "truncate", TextManipulationFunction.Truncate },
             { "trim", TextManipulationFunction.Trim },
+            { "indent", TextManipulationFunction.Indent },
             { "uripart", TextManipulationFunction.UriPart },
             { "versionmajor", VersionParseFunction.VersionMajor },
             { "versionminor", VersionParseFunction.VersionMinor },

--- a/source/Octostache/Templates/Functions/TextManipulationFunction.cs
+++ b/source/Octostache/Templates/Functions/TextManipulationFunction.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Octostache.Templates.Functions
 {
@@ -135,6 +136,96 @@ namespace Octostache.Templates.Functions
                 default:
                     return null;
             }
+        }
+
+        public static string? Indent(string? argument, string[] options)
+        {
+            if (argument == null)
+            {
+                return null;
+            }
+
+            if (argument.Length == 0)
+            {
+                // No content, no indenting
+                return string.Empty;
+            }
+
+            var indentOptions = new IndentOptions(options);
+
+            if (!indentOptions.IsValid)
+            {
+                return null;
+            }
+
+            return indentOptions.InitialIndent + argument.Replace("\n", "\n" + indentOptions.SubsequentIndent);
+        }
+
+        private class IndentOptions
+        {
+            private static Regex dualSizeEx = new Regex(@"^((\d{1,3})?/)?(\d{1,3})$", RegexOptions.Compiled);
+            public IndentOptions(string[] options)
+            {
+                if (options.Length == 0)
+                {
+                    SubsequentIndent = InitialIndent = "    ";
+                    return;
+                }
+
+                if (options.Length == 1)
+                {
+                    var dualSize = dualSizeEx.Match(options[0]);
+                    if (dualSize.Success)
+                    {
+                        var separator = dualSize.Groups[1];
+                        var initial = dualSize.Groups[2];
+                        var subsequent = dualSize.Groups[3];
+                        if (separator.Success)
+                        {
+                            // Different sized indents
+                            if (initial.Success)
+                            {
+                                if (byte.TryParse(initial.Value, out var initialIndent) && byte.TryParse(subsequent.Value, out var subsequentIndent))
+                                {
+                                    InitialIndent = new string(' ', initialIndent);
+                                    SubsequentIndent = new string(' ', subsequentIndent);
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                if (byte.TryParse(subsequent.Value, out var subsequentIndent))
+                                {
+                                    InitialIndent = string.Empty;
+                                    SubsequentIndent = new string(' ', subsequentIndent);
+                                    return;
+                                }
+                            }
+                        }
+                        else if (byte.TryParse(subsequent.Value, out var overallIndent))
+                        {
+                            InitialIndent = SubsequentIndent = new string(' ', overallIndent);
+                            return;
+                        }
+                    }
+
+                    InitialIndent = SubsequentIndent = options[0];
+                }
+                else if (options.Length == 2)
+                {
+                    InitialIndent = options[0];
+                    SubsequentIndent = options[1];
+                }
+                else
+                {
+                    InitialIndent = SubsequentIndent = string.Empty;
+                    IsValid = false;
+                }
+            }
+
+            public string InitialIndent { get; }
+            public string SubsequentIndent { get; }
+            public bool IsValid { get; } = true;
         }
 
         [return: NotNullIfNotNull("argument")]


### PR DESCRIPTION
The indent filter can be used to indent text.

By default, with no options it will add an indent of four spaces to each
line.

By supplying a single integer parameter between 0 and 255 you can adjust
the number of spaces each line is indented by. For example:

```
  #{variable | Indent 2 }
```

Will indent each line by two spaces.

If the first line needs to be indented by a different amount you can use
the following syntax:

```
  #{variable | Indent 2/4 }
```

This will indent the first line with two spaces, and subsequent lines
with four spaces.

If you don't want to indent the first line you can omit the first number
like so:

```
  #{variable | Indent /4 }
```

This will indent all lines except the first.

The maximum size of a space indent is 255.

If indenting other than spaces is required you can supply the string to
prefix each line. For example:

```
  #{variable | Indent "// " }
```

This will put `// ` at the beginning of each line.

To specify a different indent for initial/subsequent lines, pass two
options:

```
  #{if variable}/* #{variable | Indent "" " * "}
   */#{/if}
```

This uses an empty string in the first line and ` * ` in subsequent lines,
generating a multi-line block comment.

To include hashes in the indent, you need to use the escaped quoted text
format:

```
  #{variable | Indent \\"# \\"}
```