### PR TITLE
Allow nested indices to be parsed

### DIFF
--- a/source/Octostache.Tests/IterationFixture.cs
+++ b/source/Octostache.Tests/IterationFixture.cs
@@ -94,5 +94,21 @@ namespace Octostache.Tests
 
             result.Should().Be("A First:True Last:False Index:0, B First:False Last:False Index:1, C First:False Last:True Index:2, ");
         }
+
+        [Fact]
+        public void NestedIndexIterationIsSupported()
+        {
+            var result =
+                Evaluate(
+                         "#{each a in Octopus.Action.Package}#{a}: #{a.Name} #{/each}",
+                         new Dictionary<string, string>
+                         {
+                             { "Octopus.Action.Package[container[0]].Name", "A" },
+                             { "Octopus.Action.Package[container[1]].Name", "B" },
+                             { "Octopus.Action.Package[container[2]].Name", "C" },
+                         });
+
+            result.Should().Be("container[0]: A container[1]: B container[2]: C ");
+        }
     }
 }

--- a/source/Octostache.Tests/ParserFixture.cs
+++ b/source/Octostache.Tests/ParserFixture.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using FluentAssertions;
 using Octostache.Templates;
 using Xunit;
 
@@ -38,6 +39,71 @@ namespace Octostache.Tests
             result.Should().NotContain("ignored");
             result.Should().NotContain("item");
             result.Should().NotContain("item.Address");
+        }
+
+        [Fact]
+        public void NestedIndexCanBeExtracted()
+        {
+            var template = "#{Octopus.Action[].Package[containers[1].container].PackageVersion}";
+            var result = TemplateParser.ParseTemplateAndGetArgumentNames(template);
+            result.Should().Contain("[containers[1].container]");
+        }
+        
+        [Fact]
+        public void MultipleNestedIndicesCanBeExtracted()
+        {
+            var template = "#{Octopus.Action[].Package[array[foo].containers[1].container].PackageVersion}";
+            var result = TemplateParser.ParseTemplateAndGetArgumentNames(template);
+            result.Should().Contain("[array[foo].containers[1].container]");
+        }
+        
+        [Fact]
+        public void StepPackageInputsCanBeExtracted()
+        {
+            var template = @"{
+    ""name"": ""myservice"",
+    ""containers"": [
+        {
+            ""containerName"": ""nginx"",
+            ""container"": {
+                ""imageName"": ""nginx"",
+                ""imageTag"": ""#{Octopus.Action.Package[containers[0].container].PackageVersion}"",
+                ""feed"": {
+                    ""url"": ""#{Octopus.Action.Package[containers[0].container].Registry}""
+                }
+            },
+            ""memoryLimitHard"": 0
+        },
+        {
+            ""containerName"": ""busybox"",
+            ""container"": {
+                ""imageName"": ""busybox"",
+                ""imageTag"": ""#{Octopus.Action.Package[containers[1].container].PackageVersion}"",
+                ""feed"": {
+                    ""url"": ""#{Octopus.Action.Package[containers[1].container].Registry}""
+                }
+            },
+            ""memoryLimitHard"": 0
+        }
+    ],
+    ""task"": {
+        ""taskName"": """"
+    },
+    ""networkConfiguration"": {
+        ""securityGroupId"": ""foo"",
+        ""subnetId"": ""foo"",
+        ""autoAssignPublicIp"": true
+    },
+    ""desiredCount"": 1,
+    ""additionalTags"": []
+}";
+
+            // This represents what we do in calamari when processing inputs for a step package in JsonEscapeAllVariablesInOurInputs:
+            // https://github.com/OctopusDeploy/Calamari/blob/cbc46c67aa3b94e7d4b06a69c24694fb50bcb30e/source/Calamari/LaunchTools/NodeExecutor.cs#L70
+            var result = TemplateParser.ParseTemplateAndGetArgumentNames(template);
+
+            result.Should().Contain("[containers[0].container]");
+            result.Should().Contain("[containers[1].container]");
         }
     }
 }

--- a/source/Octostache.Tests/ParserFixture.cs
+++ b/source/Octostache.Tests/ParserFixture.cs
@@ -19,8 +19,6 @@ namespace Octostache.Tests
                    #{item.Address}
                 #{/each}
                 ##{ignored}
-                #{Octopus.Action[].Package[containers[1].container].PackageVersion}
-                #{Octopus.Action[].Package[array[foo].containers[1].container].PackageVersion}
             ";
 
             var result = TemplateParser.ParseTemplateAndGetArgumentNames(template, true);
@@ -35,8 +33,6 @@ namespace Octostache.Tests
                 "ifnested",
                 "comparison",
                 "List",
-                "[containers[1].container]",
-                "[array[foo].containers[1].container]"
             });
 
             result.Should().NotContain("ignored");

--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -252,6 +252,19 @@ namespace Octostache.Tests
             });
 
             result.Should().Be("docker.io");
+        }
+
+        [Fact]
+        public void JsonEscapeShouldBeSupported()
+        {
+            var result = Evaluate("#{Octopus.Action.Package[package].ExtractedPath | JsonEscape}", new Dictionary<string, string>
+            {
+                { 
+                    "Octopus.Action.Package[package].ExtractedPath", @"C:\OctopusTest\Api Test\1\Octopus-Primary\Work\20210804020317-7-11\package"
+                },
+            });
+
+            result.Should().Be(@"C:\\OctopusTest\\Api Test\\1\\Octopus-Primary\\Work\\20210804020317-7-11\\package");
         }
 
         [Fact]

--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -233,6 +233,28 @@ namespace Octostache.Tests
         }
 
         [Fact]
+        public void NestedIndexersAreSupported()
+        {
+            var result = Evaluate("#{Octopus.Action.Package[containers[0].container].Registry}", new Dictionary<string, string>
+            {
+                { "Octopus.Action.Package[containers[0].container].Registry", "docker.io" },
+            });
+
+            result.Should().Be("docker.io");
+        }
+        
+        [Fact]
+        public void MultipleNestedIndexersAreSupported()
+        {
+            var result = Evaluate("#{Octopus.Action.Package[array[foo].containers[0].container].Registry}", new Dictionary<string, string>
+            {
+                { "Octopus.Action.Package[array[foo].containers[0].container].Registry", "docker.io" },
+            });
+
+            result.Should().Be("docker.io");
+        }
+
+        [Fact]
         public void MissingVariableIndexersFailToEvaluateGracefully()
         {
             var result = Evaluate("#{Octopus.Action[#{Package}].Name}", new Dictionary<string, string>

--- a/source/Octostache/Templates/Indexer.cs
+++ b/source/Octostache/Templates/Indexer.cs
@@ -26,7 +26,7 @@ namespace Octostache.Templates
             return "[" + (IsSymbol ? "#{"+ Symbol +"}" : Index) + "]";
         }
 
-        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? (Index != null ? new string[] { $"[${Index}]" } : new string[0]);
+        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? (Index != null ? new string[] { $"[{Index}]" } : new string[0]);
 
         public override bool Equals(SymbolExpressionStep? other) => other != null && Equals((other as Indexer)!);
 

--- a/source/Octostache/Templates/Indexer.cs
+++ b/source/Octostache/Templates/Indexer.cs
@@ -26,7 +26,7 @@ namespace Octostache.Templates
             return "[" + (IsSymbol ? "#{"+ Symbol +"}" : Index) + "]";
         }
 
-        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? new string[0];
+        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? new string[]{ToString()};
 
         public override bool Equals(SymbolExpressionStep? other) => other != null && Equals((other as Indexer)!);
 

--- a/source/Octostache/Templates/Indexer.cs
+++ b/source/Octostache/Templates/Indexer.cs
@@ -26,7 +26,7 @@ namespace Octostache.Templates
             return "[" + (IsSymbol ? "#{"+ Symbol +"}" : Index) + "]";
         }
 
-        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? (Index != null ? new string[] { $"[{Index}]" } : new string[0]);
+        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? new string[0];
 
         public override bool Equals(SymbolExpressionStep? other) => other != null && Equals((other as Indexer)!);
 

--- a/source/Octostache/Templates/Indexer.cs
+++ b/source/Octostache/Templates/Indexer.cs
@@ -26,7 +26,7 @@ namespace Octostache.Templates
             return "[" + (IsSymbol ? "#{"+ Symbol +"}" : Index) + "]";
         }
 
-        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? new string[]{ToString()};
+        public override IEnumerable<string> GetArguments() => Symbol?.GetArguments() ?? (Index != null ? new string[] { $"[${Index}]" } : new string[0]);
 
         public override bool Equals(SymbolExpressionStep? other) => other != null && Equals((other as Indexer)!);
 

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -50,6 +50,8 @@ namespace Octostache.Templates
              select new Indexer((SymbolExpression)index.Expression))
             .WithPosition();
 
+        // Parsing the string of the Index, recursively parse any nested index in the string.
+        // Eg: "Package[containers[0].container].Registry"
         static readonly Parser<Indexer> StringIndexer =
             from open in Parse.Char('[')
             from parts in (from indexer in StringIndexer
@@ -65,10 +67,10 @@ namespace Octostache.Templates
                  (from open in Parse.Char('[')
                   from index in SymbolIndexer.Token()
                   from close in Parse.Char(']')
-                  select index) // NonEmpty Index
+                  select index) // NonEmpty Symbol Index
                  .Or(from index in StringIndexer
                      select index)
-                 .WithPosition()
+                 .WithPosition() // NonEmpty String Index
                  .Or(from open in Parse.Char('[')
                      from close in Parse.Char(']')
                      select new Indexer(string.Empty)) //Empty Index


### PR DESCRIPTION
With the changes done in https://github.com/OctopusDeploy/OctopusDeploy/pull/9658, the names of named packages may contain indices (eg. `containers[0].container`) which represent their path in the `Inputs` of `StepPackages`.

This is an example step's `Inputs` to be parsed:
```json
{
    ""name"": ""myservice"",
    ""containers"": [
        {
            ""containerName"": ""nginx"",
            ""container"": {
                ""imageName"": ""nginx"",
                ""imageTag"": ""#{Octopus.Action.Package[containers[0].container].PackageVersion}"",
                ""feed"": {
                    ""url"": ""#{Octopus.Action.Package[containers[0].container].Registry}""
                }
            },
            ""memoryLimitHard"": 0
        },
        {
            ""containerName"": ""busybox"",
            ""container"": {
                ""imageName"": ""busybox"",
                ""imageTag"": ""#{Octopus.Action.Package[containers[1].container].PackageVersion}"",
                ""feed"": {
                    ""url"": ""#{Octopus.Action.Package[containers[1].container].Registry}""
                }
            },
            ""memoryLimitHard"": 0
        }
    ],
    ""task"": {
        ""taskName"": """"
    },
    ""networkConfiguration"": {
        ""securityGroupId"": ""foo"",
        ""subnetId"": ""foo"",
        ""autoAssignPublicIp"": true
    },
    ""desiredCount"": 1,
    ""additionalTags"": []
}
```
In the above inputs, the variable values of `imageTag` and `url` contain nested square brackets in `Package[containers[0].container]` which causing an exception when `Octostache` trying to parse.

![image](https://user-images.githubusercontent.com/79076870/127804762-d1ba3131-ee9c-4ef1-9f9b-d640e59c4c2c.png)

This PR is to change the `Octostache` parser so that the above scenario can work.