### PR TITLE
Put quotes back in around string equality comparison

### DIFF
--- a/source/Octostache.Tests/ParserFixture.cs
+++ b/source/Octostache.Tests/ParserFixture.cs
@@ -39,5 +39,28 @@ namespace Octostache.Tests
             result.Should().NotContain("item");
             result.Should().NotContain("item.Address");
         }
+
+        [Fact]
+        public void ParsedTemplateIsConvertibleBackToString()
+        {
+            // This template is using the internal syntax, full form syntax, without omitting any spaces or #{else} statements.
+            // For example, #{if test}#{/if} has a full syntax of #{if test}#{else}#{/if}
+            var template = @"
+                #{var}
+                #{filter | Format #{option}}
+                #{nestedParent[#{nestedChild}]}
+                #{if ifvar}#{if ifnested}#{else}debug#{/if}#{else}#{/if}
+                #{if comparison != ""value"" }true#{else}#{/if}
+                #{each item in List}
+                   #{item.Address}
+                #{/each}
+                ##{ignored}
+            ";
+
+            TemplateParser.TryParseTemplate(template, out var parsedTemplate, out string error).Should().BeTrue();
+            string.IsNullOrEmpty(error).Should().BeTrue();
+            parsedTemplate.Should().NotBeNull();
+            parsedTemplate.ToString().Should().Be(template);
+        }
     }
 }

--- a/source/Octostache.Tests/ParserFixture.cs
+++ b/source/Octostache.Tests/ParserFixture.cs
@@ -45,8 +45,8 @@ namespace Octostache.Tests
         [Fact]
         public void ParsedTemplateIsConvertibleBackToString()
         {
-            // This test verifies that it is possible to convert a parsed template ToString
-            // And then find individual tokens within the template by calling ToString on each one individually
+            // This test verifies that it is possible to convert a parsed template to a string
+            // and then find individual tokens within the template by calling ToString on each token individually
             
             var template = @"
                 #{var}
@@ -67,9 +67,11 @@ namespace Octostache.Tests
                 #{MyVar | UriPart IsFile}
             ";
 
-            TemplateParser.TryParseTemplate(template, out var parsedTemplate, out string error).Should().BeTrue();
-            string.IsNullOrEmpty(error).Should().BeTrue();
-            parsedTemplate.Should().NotBeNull();
+            TemplateParser.TryParseTemplate(template, out var parsedTemplate, out string _);
+            parsedTemplate.ToString().Should().NotBeEmpty();
+            
+            // We convert the template back to the string representation and then remove individual parsed expressions until there is nothing left
+            // The purpose is to verify that both methods (on template and tokens) are deterministic and produce equivalent string representations
             string templateConvertedBackToString = parsedTemplate.ToString();
             foreach (var templateToken in parsedTemplate.Tokens)
             {

--- a/source/Octostache.Tests/ParserFixture.cs
+++ b/source/Octostache.Tests/ParserFixture.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using FluentAssertions;
+using Newtonsoft.Json;
 using Octostache.Templates;
 using Xunit;
 
@@ -43,24 +45,40 @@ namespace Octostache.Tests
         [Fact]
         public void ParsedTemplateIsConvertibleBackToString()
         {
-            // This template is using the internal syntax, full form syntax, without omitting any spaces or #{else} statements.
-            // For example, #{if test}#{/if} has a full syntax of #{if test}#{else}#{/if}
+            // This test verifies that it is possible to convert a parsed template ToString
+            // And then find individual tokens within the template by calling ToString on each one individually
+            
             var template = @"
                 #{var}
                 #{filter | Format #{option}}
                 #{nestedParent[#{nestedChild}]}
-                #{if ifvar}#{if ifnested}#{else}debug#{/if}#{else}#{/if}
-                #{if comparison != ""value"" }true#{else}#{/if}
+                #{if ifvar}#{if ifnested}#{else}debug#{/if}#{/if}
+                #{if comparison != ""value"" }true#{/if}
                 #{each item in List}
                    #{item.Address}
                 #{/each}
                 ##{ignored}
+                #{MyVar | Match ""a b""}
+                #{MyVar | StartsWith Ab}
+                #{MyVar | Match ""ab[0-9]+""}
+                #{MyVar | Match #{pattern}}
+                #{MyVar | Contains "" b(""}
+                #{ | NowDateUtc}
+                #{MyVar | UriPart IsFile}
             ";
 
             TemplateParser.TryParseTemplate(template, out var parsedTemplate, out string error).Should().BeTrue();
             string.IsNullOrEmpty(error).Should().BeTrue();
             parsedTemplate.Should().NotBeNull();
-            parsedTemplate.ToString().Should().Be(template);
+            string templateConvertedBackToString = parsedTemplate.ToString();
+            foreach (var templateToken in parsedTemplate.Tokens)
+            {
+                if (!string.IsNullOrWhiteSpace(templateToken.ToString()))
+                    templateConvertedBackToString = templateConvertedBackToString.Replace(templateToken.ToString(),  "");
+            }
+
+            templateConvertedBackToString = templateConvertedBackToString.Replace("\r\n", "");
+            templateConvertedBackToString.Trim().Should().BeEmpty();
         }
     }
 }

--- a/source/Octostache/Templates/ConditionalToken.cs
+++ b/source/Octostache/Templates/ConditionalToken.cs
@@ -52,7 +52,7 @@ namespace Octostache.Templates
     {
         public string RightSide { get; }
         public bool Equality { get; }
-        public override string EqualityText => " " + (Equality ? "==" : "!=") + " " + RightSide + " ";
+        public override string EqualityText => " " + (Equality ? "==" : "!=") + " \"" + RightSide + "\" ";
 
         public ConditionalStringExpressionToken(SymbolExpression leftSide, bool eq, string rightSide) : base(leftSide)
         {

--- a/source/Octostache/Templates/FunctionCallExpression.cs
+++ b/source/Octostache/Templates/FunctionCallExpression.cs
@@ -38,7 +38,7 @@ namespace Octostache.Templates
         public override string ToString()
         {
             if (filterSyntax)
-                return $"{Argument} | {Function}{(Options.Any() ? " " : "")}{string.Join(" ", Options.Select(t => t.ToString()))}";
+                return $"{Argument} | {Function}{(Options.Any() ? " " : "")}{string.Join(" ", Options.Select(t => t is TextToken ? $"\"{t.ToString()}\"" : t.ToString()))}";
 
 
             return $"{Function} ({string.Join(", ", GetAllArguments().Select(t => t.ToString()))})";


### PR DESCRIPTION
### Background
When parsing a template with `TemplateParser.ParseTemplate(inputs);` we expect the result of parsing to be equivalent to the unparsed string. That is to say, there should be a way to translate parsed expression back to the original. I have discovered that this doesn't work with conditional string tokens, as `ConditionalStringExpressionToken.ToString()` does not put quotes around the right side of the equation.

This is particularly handy because we would like to evaluate all variables that are passed to new step packages and json escape the resulting values:
```csharp
var template = TemplateParser.ParseTemplate(jsonInputs);
jsonInputs = template.ToString();
foreach (var templateToken in template.Tokens)
{
    var arguments = templateToken.GetArguments();
    if (!arguments.Any()) continue; // to avoid TextToken, which doesn't need to be evaluated
    string evaluated = variables.Evaluate(templateToken.ToString());
    jsonInputs = jsonInputs.Replace($"\"{templateToken.ToString()}\"", JsonConvert.ToString(evaluated));
}
```
The above works, except when there is string comparison: `#{if Octopus.Environment.Name == \"Production\"}#{TestVariable}#{/if}`

Calamari PR: https://github.com/OctopusDeploy/Calamari/pull/759

### Change
This PR simply adds quotes to `ConditionalStringExpressionToken.ToString()` so that ConditionalToken can be resolved back to the original expression if needed.

### How to review
Perhaps there is a better way to parse and json escape all variables, in which case this change is not needed. Looking for suggestions.