### PR TITLE
Removes release-related things from Cake script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -31,9 +31,6 @@ Setup(context =>
         OutputType = GitVersionOutput.Json
     });
 
-    if(BuildSystem.IsRunningOnTeamCity)
-        BuildSystem.TeamCity.SetBuildNumber(gitVersionInfo.NuGetVersion);
-
     nugetVersion = gitVersionInfo.NuGetVersion;
 
     Information("Building Octostache v{0}", nugetVersion);
@@ -113,46 +110,8 @@ Task("CopyToLocalPackages")
     CopyFileToDirectory($"{artifactsDir}/Octostache.{nugetVersion}.nupkg", localPackagesDir);
 });
 
-Task("Publish")
-    .IsDependentOn("Pack")
-    .WithCriteria(BuildSystem.IsRunningOnTeamCity)
-    .Does(() =>
-{
-    var currentBranch = GitBranchCurrent(DirectoryPath.FromString(".")).FriendlyName;
-    var octopusServer = EnvironmentVariable("OctopusServerUrl");
-    var octopusApiKey = EnvironmentVariable("OctopusServerApiKey");
-    var space = EnvironmentVariable("OctopusServerSpaceName");
-    var octopusProjectName = "Octostache";
-
-    var nugetPackage = GetFiles($"{artifactsDir}Octostache.{nugetVersion}.nupkg");
-
-    // Current config for this repo doesn't generate prerelease tags, even if we're on a development/feature branch.
-    // Using the --overwrite-mode=IgnoreIfExists flag instructs the target Octopus server to ignore any attempted uploads with the same verison number.
-    // This decision is made server-side, so you'll still see log messages indicating the package was uploaded. Never fear, the push is discarded if the version already exists. 
-    // You can verify this by looking at the SHA1 and Published date of the package in the package feed: it won't change on subsequent pushes.
-    OctoPush(octopusServer, octopusApiKey, nugetPackage, new OctopusPushSettings 
-    {
-        ArgumentCustomization = args => args.Append("--overwrite-mode=IgnoreIfExists"),
-        Space = space 
-    });
-
-    // Config-as-Code doesn't yet support Automatic Release Creation, so do it manually
-    OctoCreateRelease(octopusProjectName, new CreateReleaseSettings {
-        ArgumentCustomization = args => args.Append($"--gitRef={currentBranch}"),
-        Server = octopusServer,
-        ApiKey = octopusApiKey,
-        ReleaseNumber = nugetVersion,
-        Space = space,
-        Packages = new Dictionary<string, string>
-        {
-            { "Octostache", nugetVersion }
-        },
-        IgnoreExisting = true
-     });
-});
-
 Task("Default")
-    .IsDependentOn("Publish")
+    .IsDependentOn("Pack")
     .IsDependentOn("CopyToLocalPackages");
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Removes release creation from Cake script (this has been moved to our internal build server instead)
* Sets the default Cake task to "Pack" instead of "Publish"