### PR TITLE
Adds ability to reverse iteration order

### DIFF
--- a/source/Octostache.Tests/IterationFixture.cs
+++ b/source/Octostache.Tests/IterationFixture.cs
@@ -109,5 +109,19 @@ namespace Octostache.Tests
 
             result.Should().Be("container[0]: A container[1]: B container[2]: C ");
         }
+
+        [Fact]
+        public void ReverseIterationIsSupported()
+        {
+            var variables = new Dictionary<string, string>
+            {
+                { "List[0]", "a" },
+                { "List[1]", "b" },
+                { "List[2]", "c" },
+            };
+
+            var result = Evaluate("#{each item in reversed List}#{item}#{/each}", variables);
+            result.Should().Be("cba");
+        }
     }
 }

--- a/source/Octostache/Templates/RepetitionToken.cs
+++ b/source/Octostache/Templates/RepetitionToken.cs
@@ -9,12 +9,14 @@ namespace Octostache.Templates
         public SymbolExpression Collection { get; }
         public Identifier Enumerator { get; }
         public TemplateToken[] Template { get; }
+        public bool Reversed { get; }
 
-        public RepetitionToken(SymbolExpression collection, Identifier enumerator, IEnumerable<TemplateToken> template)
+        public RepetitionToken(SymbolExpression collection, Identifier enumerator, IEnumerable<TemplateToken> template, string sorting)
         {
             Collection = collection;
             Enumerator = enumerator;
             Template = template.ToArray();
+            Reversed = sorting == "reversed";
         }
 
         public override string ToString()

--- a/source/Octostache/Templates/TemplateEvaluator.cs
+++ b/source/Octostache/Templates/TemplateEvaluator.cs
@@ -70,6 +70,9 @@ namespace Octostache.Templates
             var items = context.ResolveAll(rt.Collection, out innerTokens).ToArray();
             missingTokens.AddRange(innerTokens);
 
+            if (rt.Reversed)
+                items = items.Reverse().ToArray();
+
             for (var i = 0; i < items.Length; ++i)
             {
                 var item = items[i];

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -154,11 +154,12 @@ namespace Octostache.Templates
                 from sp in Parse.WhiteSpace.AtLeastOnce()
                 from enumerator in Identifier.Token()
                 from keyIn in Keyword("in").Token()
+                from keyReversed in Keyword("reversed").Token().Optional()
                 from expression in Symbol.Token()
                 from rightDelim in RDelim
                 from body in Parse.Ref(() => Template)
                 from end in Parse.String("#{/each}")
-                select new RepetitionToken(expression, enumerator, body))
+                select new RepetitionToken(expression, enumerator, body, keyReversed.GetOrElse(null)))
             .WithPosition();
 
         static readonly Parser<TextToken> Text =


### PR DESCRIPTION
# Changes
Adds a new "reversed" keyword to the end of the #{each} construct, so that users can write templates like:

```
#{each note in Package.ReleaseNotes reversed}
  * #{note}
#{/each}
```

The template will reverse the contents of the collection before iterating.

# Linked Issues
* Closes OctopusDeploy/Octostache#52