### PR TITLE
Enable multiple spaces before pipe symbol

### DIFF
--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -20,10 +20,19 @@ namespace Octostache.Tests
             result.Should().Be("result");
         }
 
-        [Fact]
-        public void ConditionalIsSupportedWithLeadingWhitespace()
+        [Theory]
+        [InlineData("#{ if Truthy}#{Result}#{/if}")]
+        [InlineData("#{  if Truthy}#{Result}#{/if}")]
+        [InlineData("#{if Truthy }#{Result}#{/if}")]
+        [InlineData("#{ if Truthy  }#{Result}#{/if}")]
+        [InlineData("#{if  Truthy}#{Result}#{/if}")]
+        [InlineData("#{if Truthy}#{ Result}#{/if}")]
+        [InlineData("#{if Truthy}#{  Result}#{/if}")]
+        [InlineData("#{if Truthy}#{Result }#{/if}")]
+        [InlineData("#{if Truthy}#{Result  }#{/if}")]
+        public void ConditionalIgnoresWhitespacesCorrectly(string input)
         {
-            var result = Evaluate("#{ if Truthy}#{Result}#{/if}",
+            var result = Evaluate(input,
                 new Dictionary<string, string>
                 {
                     { "Result", "result" },
@@ -33,28 +42,6 @@ namespace Octostache.Tests
             result.Should().Be("result");
 
             result = Evaluate("#{  if Truthy}#{Result}#{/if}",
-                new Dictionary<string, string>
-                {
-                    { "Result", "result" },
-                    { "Truthy", "true" },
-                });
-
-            result.Should().Be("result");
-        }
-
-        [Fact]
-        public void ConditionalIsSupportedWithTrailingWhitespace()
-        {
-            var result = Evaluate("#{if Truthy }#{Result}#{/if}",
-                new Dictionary<string, string>
-                {
-                    { "Result", "result" },
-                    { "Truthy", "true" },
-                });
-
-            result.Should().Be("result");
-
-            result = Evaluate("#{if Truthy  }#{Result}#{/if}",
                 new Dictionary<string, string>
                 {
                     { "Result", "result" },

--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -30,6 +30,8 @@ namespace Octostache.Tests
         [InlineData("#{if Truthy}#{  Result}#{/if}")]
         [InlineData("#{if Truthy}#{Result }#{/if}")]
         [InlineData("#{if Truthy}#{Result  }#{/if}")]
+        [InlineData("#{if Truthy  == \"true\"}#{Result}#{/if}")]
+        [InlineData("#{if Truthy  != \"false\"}#{Result}#{/if}")]
         public void ConditionalIgnoresWhitespacesCorrectly(string input)
         {
             var result = Evaluate(input,

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -59,7 +59,7 @@ namespace Octostache.Tests
             var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "Abc" } });
             result.Should().Be("ABC");
         }
-        
+
         [Theory]
         [InlineData("A&'bc", "A&amp;&apos;bc")]
         [InlineData("", "")]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -46,6 +46,21 @@ namespace Octostache.Tests
         }
 
         [Theory]
+        [InlineData("#{Foo|ToUpper}")]
+        [InlineData("#{Foo | ToUpper}")]
+        [InlineData("#{Foo  | ToUpper}")]
+        [InlineData("#{Foo |  ToUpper}")]
+        [InlineData("#{ Foo | ToUpper}")]
+        [InlineData("#{  Foo | ToUpper}")]
+        [InlineData("#{Foo | ToUpper }")]
+        [InlineData("#{Foo | ToUpper  }")]
+        public void WhiteSpacesAreIgnored(string input)
+        {
+            var result = Evaluate(input, new Dictionary<string, string> { { "Foo", "Abc" } });
+            result.Should().Be("ABC");
+        }
+        
+        [Theory]
         [InlineData("A&'bc", "A&amp;&apos;bc")]
         [InlineData("", "")]
         [InlineData(null, "")]

--- a/source/Octostache.Tests/IterationFixture.cs
+++ b/source/Octostache.Tests/IterationFixture.cs
@@ -30,6 +30,32 @@ namespace Octostache.Tests
             result.Should().Be("Package A-APackage B-B-Blank");
         }
 
+        [Theory]
+        [InlineData("#{ each a in Octopus.Action}#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{  each a in Octopus.Action}#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each  a in Octopus.Action}#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a  in Octopus.Action}#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in  Octopus.Action}#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action }#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action  }#{a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action}#{ a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action}#{  a}-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action}#{a }-#{a.Name}#{/each}")]
+        [InlineData("#{each a in Octopus.Action}#{a  }-#{a.Name}#{/each}")]
+        public void IterationIgnoresWhitespacesCorrectly(string input)
+        {
+            var result = Evaluate(
+                input,
+                new Dictionary<string, string>
+                {
+                    { "Octopus.Action[Package A].Name", "A" },
+                    { "Octopus.Action[Package B].Name", "B" },
+                    { "Octopus.Action[].Name", "Blank" },
+                });
+
+            result.Should().Be("Package A-APackage B-B-Blank");
+        }
+        
         [Fact]
         public void NestedIterationIsSupported()
         {

--- a/source/Octostache.Tests/IterationFixture.cs
+++ b/source/Octostache.Tests/IterationFixture.cs
@@ -55,7 +55,7 @@ namespace Octostache.Tests
 
             result.Should().Be("Package A-APackage B-B-Blank");
         }
-        
+
         [Fact]
         public void NestedIterationIsSupported()
         {

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -14,7 +14,7 @@ namespace Octostache.Templates
     {
         static readonly Parser<Identifier> Identifier = Parse
             .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
-            .Except(Parse.WhiteSpace.FollowedBy("|"))
+            .Except(Parse.WhiteSpace.Many().FollowedBy("|"))
             .Except(Parse.WhiteSpace.Many().FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()
             .AtLeastOnce()
@@ -24,7 +24,7 @@ namespace Octostache.Templates
 
         static readonly Parser<Identifier> IdentifierWithoutWhitespace = Parse
             .Char(c => char.IsLetter(c) || char.IsDigit(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
-            .Except(Parse.WhiteSpace.FollowedBy("|"))
+            .Except(Parse.WhiteSpace.Many().FollowedBy("|"))
             .Except(Parse.WhiteSpace.Many().FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()
             .AtLeastOnce()

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -150,8 +150,9 @@ namespace Octostache.Templates
 
         static readonly Parser<RepetitionToken> Repetition =
             (from leftDelim in LDelim
+                from sp1 in Parse.WhiteSpace.Many()
                 from keyEach in Keyword("each")
-                from sp in Parse.WhiteSpace.AtLeastOnce()
+                from sp2 in Parse.WhiteSpace.AtLeastOnce()
                 from enumerator in Identifier.Token()
                 from keyIn in Keyword("in").Token()
                 from expression in Symbol.Token()

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -14,22 +14,22 @@ namespace Octostache.Templates
     {
         static readonly Parser<Identifier> Identifier = Parse
             .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
-            .Except(Parse.WhiteSpace.Many().FollowedBy("|"))
-            .Except(Parse.WhiteSpace.Many().FollowedBy("}"))
+            .Except(Parse.WhiteSpace.FollowedBy("|"))
+            .Except(Parse.WhiteSpace.FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()
             .AtLeastOnce()
             .Text()
-            .Select(s => new Identifier(s))
+            .Select(s => new Identifier(s.Trim()))
             .WithPosition();
 
         static readonly Parser<Identifier> IdentifierWithoutWhitespace = Parse
             .Char(c => char.IsLetter(c) || char.IsDigit(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
-            .Except(Parse.WhiteSpace.Many().FollowedBy("|"))
-            .Except(Parse.WhiteSpace.Many().FollowedBy("}"))
+            .Except(Parse.WhiteSpace.FollowedBy("|"))
+            .Except(Parse.WhiteSpace.FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()
             .AtLeastOnce()
             .Text()
-            .Select(s => new Identifier(s))
+            .Select(s => new Identifier(s.Trim()))
             .WithPosition();
 
         static readonly Parser<string> LDelim = Parse.String("#{").Except(Parse.String("#{/")).Text();


### PR DESCRIPTION
This PR resolves https://github.com/OctopusDeploy/Issues/issues/7613 where when more than one spaces appears before the pipe symbol (`|`) in filters expression, the expression cannot be parsed correctly. For example, 
```csharp
[Fact]
public void MultipleSpacesTest()
{
    var result = Evaluate("#{Foo  | ToUpper}", new Dictionary<string, string> { { "Foo", "Abc" } });
    result.Should().Be("ABC");
}
```
will fail (note there are two spaces before `|`) because the actually parsed symbol is `Foo ` (with a trailing space) rather than `Foo`. If you define the value for `Foo ` instead, it can pass.
