### PR TITLE
Enable function calls in #{if} expressions

### DIFF
--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -106,7 +106,7 @@ namespace Octostache.Tests
 
             result.Should().Be("result");
         }
-        
+
         [Fact]
         public void ConditionalNegationIsSupportedWhenStringIsOnTheLeftHandSide()
         {
@@ -199,10 +199,10 @@ namespace Octostache.Tests
                     { "Hello", "HELLO" },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be("result");
         }
-        
+
         [Fact]
         public void FunctionCallIsSupportedWithStringOnTheRightHandSide()
         {
@@ -212,10 +212,10 @@ namespace Octostache.Tests
                     { "Hello", "HELLO" },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be("result");
         }
-        
+
         [Fact]
         public void FunctionCallIsSupportedWithStringOnTheLeftHandSide()
         {
@@ -225,10 +225,10 @@ namespace Octostache.Tests
                     { "Hello", "HELLO" },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be("result");
         }
-        
+
         [Fact]
         public void FunctionCallIsSupportedOnBothSide()
         {
@@ -239,10 +239,10 @@ namespace Octostache.Tests
                     { "Hello", "HELLO" },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be("result");
         }
-        
+
         [Fact]
         public void ChainedFunctionCallIsSupported()
         {
@@ -253,21 +253,21 @@ namespace Octostache.Tests
                     { "Hello", "  HELLO " },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be("result");
         }
-        
-        
+
         [Fact]
         public void UnknownFunctionsAreEchoed()
         {
             const string template = "#{if Greeting | NonExistingFunction}#{Result}#{/if}";
-            var result = Evaluate(template, new Dictionary<string, string>
+            var result = Evaluate(template,
+                new Dictionary<string, string>
                 {
                     { "Greeting", "Hello world" },
                     { "Result", "result" },
                 });
-        
+
             result.Should().Be(template);
         }
     }

--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -81,7 +81,7 @@ namespace Octostache.Tests
         }
 
         [Fact]
-        public void ConditionalToStringIsSupported()
+        public void ConditionalToStringIsSupportedWhenStringIsOnTheRightHandSide()
         {
             var result = Evaluate("#{if Octopus == \"octopus\"}#{Result}#{/if}",
                 new Dictionary<string, string>
@@ -94,7 +94,33 @@ namespace Octostache.Tests
         }
 
         [Fact]
-        public void ConditionalNegationIsSupported()
+        public void ConditionalToStringIsSupportedWhenStringIsOnTheLeftHandSide()
+        {
+            var result = Evaluate("#{if \"octopus\" == Octopus }#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Result", "result" },
+                    { "Octopus", "octopus" },
+                });
+
+            result.Should().Be("result");
+        }
+        
+        [Fact]
+        public void ConditionalNegationIsSupportedWhenStringIsOnTheLeftHandSide()
+        {
+            var result = Evaluate("#{if \"software\" != Octopus}#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Result", "result" },
+                    { "software", "something else" },
+                });
+
+            result.Should().Be("result");
+        }
+
+        [Fact]
+        public void ConditionalNegationIsSupportedWhenStringIsOnTheRightHandSide()
         {
             var result = Evaluate("#{if Octopus != \"software\"}#{Result}#{/if}",
                 new Dictionary<string, string>
@@ -106,6 +132,7 @@ namespace Octostache.Tests
             result.Should().Be("result");
         }
 
+        
         [Fact]
         public void NestedConditionalsAreSupported()
         {
@@ -161,6 +188,19 @@ namespace Octostache.Tests
                 });
 
             result.Should().Be("elseresult");
+        }
+
+        [Fact]
+        public void FunctionCallIsSupportedForEquality()
+        {
+            var result = Evaluate("#{if Hello | ToLower == \"hello\"}#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    {"Hello", "HELLO"},
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be("result");
         }
     }
 }

--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -114,7 +114,7 @@ namespace Octostache.Tests
                 new Dictionary<string, string>
                 {
                     { "Result", "result" },
-                    { "software", "something else" },
+                    { "Octopus", "something else" },
                 });
 
             result.Should().Be("result");
@@ -127,13 +127,12 @@ namespace Octostache.Tests
                 new Dictionary<string, string>
                 {
                     { "Result", "result" },
-                    { "software", "something else" },
+                    { "Octopus", "something else" },
                 });
 
             result.Should().Be("result");
         }
 
-        
         [Fact]
         public void NestedConditionalsAreSupported()
         {
@@ -258,5 +257,18 @@ namespace Octostache.Tests
             result.Should().Be("result");
         }
         
+        
+        [Fact]
+        public void UnknownFunctionsAreEchoed()
+        {
+            const string template = "#{if Greeting | NonExistingFunction}#{Result}#{/if}";
+            var result = Evaluate(template, new Dictionary<string, string>
+                {
+                    { "Greeting", "Hello world" },
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be(template);
+        }
     }
 }

--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -32,6 +32,7 @@ namespace Octostache.Tests
         [InlineData("#{if Truthy}#{Result  }#{/if}")]
         [InlineData("#{if Truthy  == \"true\"}#{Result}#{/if}")]
         [InlineData("#{if Truthy  != \"false\"}#{Result}#{/if}")]
+        [InlineData("#{if Truthy  |  ToLower  != \"false\"}#{Result}#{/if}")]
         public void ConditionalIgnoresWhitespacesCorrectly(string input)
         {
             var result = Evaluate(input,
@@ -191,16 +192,71 @@ namespace Octostache.Tests
         }
 
         [Fact]
-        public void FunctionCallIsSupportedForEquality()
+        public void FunctionCallIsSupported()
         {
-            var result = Evaluate("#{if Hello | ToLower == \"hello\"}#{Result}#{/if}",
+            var result = Evaluate("#{if Hello | Contains \"O\" }#{Result}#{/if}",
                 new Dictionary<string, string>
                 {
-                    {"Hello", "HELLO"},
+                    { "Hello", "HELLO" },
                     { "Result", "result" },
                 });
         
             result.Should().Be("result");
         }
+        
+        [Fact]
+        public void FunctionCallIsSupportedWithStringOnTheRightHandSide()
+        {
+            var result = Evaluate("#{if Hello | ToLower == \"hello\"}#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Hello", "HELLO" },
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be("result");
+        }
+        
+        [Fact]
+        public void FunctionCallIsSupportedWithStringOnTheLeftHandSide()
+        {
+            var result = Evaluate("#{if \"hello\" == Hello | ToLower }#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Hello", "HELLO" },
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be("result");
+        }
+        
+        [Fact]
+        public void FunctionCallIsSupportedOnBothSide()
+        {
+            var result = Evaluate("#{if Greeting | ToLower == Hello | ToLower }#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Greeting", "Hello" },
+                    { "Hello", "HELLO" },
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be("result");
+        }
+        
+        [Fact]
+        public void ChainedFunctionCallIsSupported()
+        {
+            var result = Evaluate("#{if Greeting | Trim | ToUpper | ToLower == Hello | ToBase64 | FromBase64 | Trim | ToLower }#{Result}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Greeting", " Hello " },
+                    { "Hello", "  HELLO " },
+                    { "Result", "result" },
+                });
+        
+            result.Should().Be("result");
+        }
+        
     }
 }

--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -297,6 +297,43 @@ namespace Octostache.Tests
             result.Should().Be("#{MY_VAR[#{foo}]}");
         }
 
+        [Theory]
+        [InlineData("#{if Octopus.IsCool}#{Result}#{/if}")]
+        [InlineData("#{if Octopus.CoolState == \"Cool\"}#{Result}#{/if}")]
+        [InlineData("#{if Octopus.CoolState != \"Uncool\"}#{Result}#{/if}")]
+        [InlineData("#{unless Octopus.CoolState == \"Uncool\"}#{Result}#{/unless}")]
+        [InlineData("#{if Octopus.Appraise == Octopus.CoolState}#{Result}#{/if}")]
+        public void ConditionalsAreSupported(string template)
+        {
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "Result", "Cool" },
+                    { "Octopus.IsCool", "true" },
+                    { "Octopus.CoolState", "Cool" },
+                    { "Octopus.Appraise", "Cool" },
+                });
+            result.Should().Be("Cool");
+        }
+
+        [Theory]
+        [InlineData("#{if Octopus.CoolState | ToUpper == \"COOL\"}#{Result}#{/if}")]
+        [InlineData("#{if Octopus.CoolState | ToUpper | ToLower == \"cool\"}#{Result}#{/if}")]
+        [InlineData("#{if \"cool\" == Octopus.CoolState | ToLower}#{Result}#{/if}")]
+        [InlineData("#{if Octopus.CoolState | ToLower == Octopus.Appraise | ToLower | Trim }#{Result}#{/if}")]
+        [InlineData("#{if Octopus.Appraise | ToLower | Contains #{Octopus.CoolState | ToLower} }#{Result}#{/if}")]
+        public void FiltersInConditionalsAreSupported(string template)
+        {
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "Result", "Cool" },
+                    { "Octopus.CoolState", "Cool" },
+                    { "Octopus.Appraise", " Cool " },
+                });
+            result.Should().Be("Cool");
+        }
+
         [Fact]
         public void IterationOverAnEmptyCollectionIsFine()
         {
@@ -356,7 +393,7 @@ namespace Octostache.Tests
         }
 
         [Fact]
-        public void IndexWithUnkownVariableDoesntFail()
+        public void IndexWithUnknownVariableDoesntFail()
         {
             var pattern = "#{Location[#{Continent}]}";
 

--- a/source/Octostache/Templates/ConditionalToken.cs
+++ b/source/Octostache/Templates/ConditionalToken.cs
@@ -34,10 +34,10 @@ namespace Octostache.Templates
 
     class ConditionalExpressionToken : TemplateToken
     {
-        public SymbolExpression LeftSide { get; }
+        public ContentExpression LeftSide { get; }
         public virtual string EqualityText => "";
 
-        public ConditionalExpressionToken(SymbolExpression leftSide)
+        public ConditionalExpressionToken(ContentExpression leftSide)
         {
             LeftSide = leftSide;
         }
@@ -51,7 +51,7 @@ namespace Octostache.Templates
         public bool Equality { get; }
         public override string EqualityText => " " + (Equality ? "==" : "!=") + " \"" + RightSide + "\" ";
 
-        public ConditionalStringExpressionToken(SymbolExpression leftSide, bool eq, string rightSide) : base(leftSide)
+        public ConditionalStringExpressionToken(ContentExpression leftSide, bool eq, string rightSide) : base(leftSide)
         {
             Equality = eq;
             RightSide = rightSide;
@@ -65,11 +65,11 @@ namespace Octostache.Templates
 
     class ConditionalSymbolExpressionToken : ConditionalExpressionToken
     {
-        public SymbolExpression RightSide { get; }
+        public ContentExpression RightSide { get; }
         public bool Equality { get; }
         public override string EqualityText => " " + (Equality ? "==" : "!=") + " " + RightSide + " ";
 
-        public ConditionalSymbolExpressionToken(SymbolExpression leftSide, bool eq, SymbolExpression rightSide) : base(leftSide)
+        public ConditionalSymbolExpressionToken(ContentExpression leftSide, bool eq, ContentExpression rightSide) : base(leftSide)
         {
             Equality = eq;
             RightSide = rightSide;

--- a/source/Octostache/Templates/ConditionalToken.cs
+++ b/source/Octostache/Templates/ConditionalToken.cs
@@ -8,6 +8,8 @@ namespace Octostache.Templates
     /// Example: <code>#{if Octopus.IsCool}...#{/if}</code>
     /// Example: <code>#{if Octopus.CoolStatus != "Uncool"}...#{/if}</code>
     /// Example: <code>#{if Octopus.IsCool == Octostache.IsCool}...#{/if}</code>
+    /// Example: <code>#{if "Cool" == Octostache.CoolStatus}...#{/if}</code>
+    /// Example: <code>#{if Octopus.CoolStatus | ToLower | StartsWith "cool"}...#{/if}</code>
     /// </summary>
     class ConditionalToken : TemplateToken
     {
@@ -22,7 +24,11 @@ namespace Octostache.Templates
             FalsyTemplate = falsyBranch.ToArray();
         }
 
-        public override string ToString() => "#{if " + Token.LeftSide + Token.EqualityText + "}" + string.Join("", TruthyTemplate.Cast<object>()) + "#{else}" + string.Join("", FalsyTemplate.Cast<object>()) + "#{/if}";
+        public override string ToString() => 
+            "#{if " + Token.LeftSide + Token.EqualityText + "}" +
+            string.Join("", TruthyTemplate.Cast<object>()) + 
+            (FalsyTemplate.Length == 0 ? "" : "#{else}" + string.Join("", FalsyTemplate.Cast<object>())) +
+            "#{/if}";
 
         public override IEnumerable<string> GetArguments()
         {

--- a/source/Octostache/Templates/ConditionalToken.cs
+++ b/source/Octostache/Templates/ConditionalToken.cs
@@ -24,11 +24,8 @@ namespace Octostache.Templates
             FalsyTemplate = falsyBranch.ToArray();
         }
 
-        public override string ToString() => 
-            "#{if " + Token.LeftSide + Token.EqualityText + "}" +
-            string.Join("", TruthyTemplate.Cast<object>()) + 
-            (FalsyTemplate.Length == 0 ? "" : "#{else}" + string.Join("", FalsyTemplate.Cast<object>())) +
-            "#{/if}";
+        public override string ToString() =>
+            "#{if " + Token.LeftSide + Token.EqualityText + "}" + string.Join("", TruthyTemplate.Cast<object>()) + (FalsyTemplate.Length == 0 ? "" : "#{else}" + string.Join("", FalsyTemplate.Cast<object>())) + "#{/if}";
 
         public override IEnumerable<string> GetArguments()
         {

--- a/source/Octostache/Templates/TemplateAnalyzer.cs
+++ b/source/Octostache/Templates/TemplateAnalyzer.cs
@@ -35,15 +35,15 @@ namespace Octostache.Templates
             {
                 foreach (var symbol in GetSymbols(ct.Token.LeftSide))
                 {
-                   yield return context.Expand(symbol); 
+                    yield return context.Expand(symbol);
                 }
-                    
+
                 var exp = ct.Token as ConditionalSymbolExpressionToken;
                 if (exp != null)
                 {
                     foreach (var symbol in GetSymbols(exp.RightSide))
                     {
-                       yield return context.Expand(symbol); 
+                        yield return context.Expand(symbol);
                     }
                 }
 

--- a/source/Octostache/Templates/TemplateAnalyzer.cs
+++ b/source/Octostache/Templates/TemplateAnalyzer.cs
@@ -33,11 +33,18 @@ namespace Octostache.Templates
             var ct = token as ConditionalToken;
             if (ct != null)
             {
-                yield return context.Expand(ct.Token.LeftSide);
+                foreach (var symbol in GetSymbols(ct.Token.LeftSide))
+                {
+                   yield return context.Expand(symbol); 
+                }
+                    
                 var exp = ct.Token as ConditionalSymbolExpressionToken;
                 if (exp != null)
                 {
-                    yield return context.Expand(exp.RightSide);
+                    foreach (var symbol in GetSymbols(exp.RightSide))
+                    {
+                       yield return context.Expand(symbol); 
+                    }
                 }
 
                 foreach (var templateDependency in GetDependencies(ct.TruthyTemplate.Concat(ct.FalsyTemplate), context))

--- a/source/Octostache/Templates/TemplateEvaluator.cs
+++ b/source/Octostache/Templates/TemplateEvaluator.cs
@@ -102,9 +102,7 @@ namespace Octostache.Templates
 
         void EvaluateConditionalToken(EvaluationContext context, ConditionalToken ct)
         {
-            string[] innerTokens;
-            var leftSide = context.Resolve(ct.Token.LeftSide, out innerTokens);
-            missingTokens.AddRange(innerTokens);
+            var leftSide = Calculate(ct.Token.LeftSide, context);
 
             var eqToken = ct.Token as ConditionalStringExpressionToken;
             if (eqToken != null)
@@ -124,8 +122,7 @@ namespace Octostache.Templates
             {
                 var comparer = symToken.Equality ? new Func<string, string, bool>((x, y) => x == y) : (x, y) => x != y;
 
-                var rightSide = context.Resolve(symToken.RightSide, out _);
-                missingTokens.AddRange(innerTokens);
+                var rightSide = Calculate(symToken.RightSide, context);
 
                 if (comparer(leftSide, rightSide))
                     Evaluate(ct.TruthyTemplate, context);

--- a/source/Octostache/Templates/TemplateEvaluator.cs
+++ b/source/Octostache/Templates/TemplateEvaluator.cs
@@ -103,7 +103,13 @@ namespace Octostache.Templates
         void EvaluateConditionalToken(EvaluationContext context, ConditionalToken ct)
         {
             var leftSide = Calculate(ct.Token.LeftSide, context);
-
+            if (leftSide == null)
+            {
+                context.Output.Write(ct.ToString());
+                missingTokens.Add(ct.Token.LeftSide.ToString());
+                return;
+            }
+            
             var eqToken = ct.Token as ConditionalStringExpressionToken;
             if (eqToken != null)
             {
@@ -123,6 +129,12 @@ namespace Octostache.Templates
                 var comparer = symToken.Equality ? new Func<string, string, bool>((x, y) => x == y) : (x, y) => x != y;
 
                 var rightSide = Calculate(symToken.RightSide, context);
+                if (rightSide == null)
+                {
+                    context.Output.Write(ct.ToString());
+                    missingTokens.Add(symToken.RightSide.ToString());
+                    return;
+                }
 
                 if (comparer(leftSide, rightSide))
                     Evaluate(ct.TruthyTemplate, context);

--- a/source/Octostache/Templates/TemplateEvaluator.cs
+++ b/source/Octostache/Templates/TemplateEvaluator.cs
@@ -109,7 +109,7 @@ namespace Octostache.Templates
                 missingTokens.Add(ct.Token.LeftSide.ToString());
                 return;
             }
-            
+
             var eqToken = ct.Token as ConditionalStringExpressionToken;
             if (eqToken != null)
             {

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -139,7 +139,7 @@ namespace Octostache.Templates
                 let isEq = eq == "=="
                 select new ConditionalSymbolExpressionToken(expression, isEq, compareTo))
             .WithPosition();
-        
+
         static readonly Parser<string> QuotedText =
             (from open in Parse.Char('"')
                 from content in Parse.CharExcept(new[] { '"', '#' }).Many().Text()
@@ -151,14 +151,14 @@ namespace Octostache.Templates
                 from content in Parse.AnyChar.Until(Parse.String("\\\"")).Text()
                 select content).Token();
 
-        static readonly Parser<ConditionalExpressionToken> LeftStringMatch = 
+        static readonly Parser<ConditionalExpressionToken> LeftStringMatch =
             (from compareTo in QuotedText.Token().Or(EscapedQuotedText.Token())
                 from eq in Keyword("==").Token().Or(Keyword("!=").Token())
                 from expression in Expression.Token()
                 let isEq = eq == "=="
                 select new ConditionalStringExpressionToken(expression, isEq, compareTo))
             .WithPosition();
-        
+
         static readonly Parser<ConditionalExpressionToken> RightStringMatch =
             (from expression in Expression.Token()
                 from eq in Keyword("==").Token().Or(Keyword("!=").Token())
@@ -190,7 +190,7 @@ namespace Octostache.Templates
                 .AtLeastOnce()
                 .Select(s => new TextToken(s.ToArray()))
                 .WithPosition();
-        
+
         static readonly Parser<TemplateToken> Token =
             Conditional.Select(t => (TemplateToken) t)
                 .Or(Repetition)

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -132,7 +132,7 @@ namespace Octostache.Templates
                 select new ConditionalExpressionToken(expression))
             .WithPosition();
 
-        static readonly Parser<ConditionalExpressionToken> TokenMatch =
+        static readonly Parser<ConditionalExpressionToken> StringMatch =
             (from expression in Symbol.Token()
                 from eq in Keyword("==").Token().Or(Keyword("!=").Token())
                 from compareTo in QuotedText.Token().Or(EscapedQuotedText.Token())
@@ -140,7 +140,7 @@ namespace Octostache.Templates
                 select new ConditionalStringExpressionToken(expression, isEq, compareTo))
             .WithPosition();
 
-        static readonly Parser<ConditionalExpressionToken> StringMatch =
+        static readonly Parser<ConditionalExpressionToken> TokenMatch =
             (from expression in Symbol.Token()
                 from eq in Keyword("==").Token().Or(Keyword("!=").Token())
                 from compareTo in Symbol.Token()


### PR DESCRIPTION
## Background

The PR closes #65.

Previously, for `#{if}` and `#{unless}` statements, we supported three types of expressions to be used as the condition:
1. `#{if <token>} ... #{/if}` where we test whether the value of `<token>` itself is falsy (i.e. "0", "no" or "false");
2. `#{if <token> == "string"} ... #{/if}` where the value of `<token>` is compared against a string. In this case, the string must appear on the right hand side of comparison;
3. `#{if <token1> == <token2>}` where 2 tokens are compared.

The `<token>`s here must be either a variable name (e.g. `Octopus.Web.BaseUrl`), or a variable name combined with indexers (`[ ... ]`) and properties accesses (`.`) (e.g. `Octopus.Action.Package[array[foo].containers[0].container].Registry`).

However, function calls (`|`) which are supported in normal substitutions (e.g. `#{Name | ToUpper}`) are not supported in `#{if}` statements. As a result, the users cannot write things like 
- `#{if MyVar | Trim == ""}`, 
- `#{if ProjectName | ToLower | Contains "octopus"}` 
and so on which would make their template much more succinct.

## Results
This PR adds supports to these use cases. Now, in addition to the originally allowed syntax, the user can also use functions in conditionals:

- `#{if ProjectName | ToLower | Contains "octopus"}` - use functions directly;
- `#{if ProjectName | ToLower == "MyProject"}` - use functions to compare against a string;
- `#{if "MyProject" == ProjectName | ToLower | Trim}` - string can appear on the left hand side as well, useful if the chained function calls become very long;
- `#{if ProjectName | ToLower | Trim == DefaultProjectName | ToLower | Trim}` - functions are supported on both sides of the comparison.

## Limitations
These use cases are NOT supported:
- `#{if "hello" == "hello"}` - compare string to string, because this is unnecessary since the result of the condition is already known
- `#{if "false"}` - directly use a string as the condition, because this is unnecessary
- `#{if "MyProject" | ToLower | EndsWith "project"}` - function calls on a string value, because the result is known
- `#{if ProjectName | ToUpper | Contains (DefaultProjectName | ToUpper)}` - associate the function call from the right hand side. The brackets are not supported, and a chained function call expression is always evaluated from left to right. So the only supported syntax is `#{if ProjectName | ToUpper | Contains DefaultProjectName | ToUpper}` (without brackets), which will be evaluated in the order of `((ProjectName | ToUpper) | Contains DefaultProjectName) | ToUpper` (which may evaluate to `"TRUE"` or `"FALSE"`). This is consistent with the current behaviour of function calls when used in normal substitutions.