### PR TITLE
Make sure unknown variables behave the same as before

### DIFF
--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -67,6 +67,22 @@ namespace Octostache.Tests
             result.Should().Be("result");
         }
 
+        [Theory]
+        [InlineData("#{if MyVar}True#{/if}", "")]
+        [InlineData("#{unless MyVar}False#{/unless}", "False")]
+        public void UnknownVariablesAreTreatedAsFalsy(string template, string expected)
+        {
+            var result = Evaluate(template, new Dictionary<string, string>());
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void UnknownVariablesOnBothSidesAreTreatedAsEqual()
+        {
+            var result = Evaluate("#{if Unknown1 == Unknown2}Equal#{/if}", new Dictionary<string, string>());
+            result.Should().Be("Equal");
+        }
+
         [Fact]
         public void ConditionalToOtherDictValueIsSupported()
         {
@@ -266,6 +282,20 @@ namespace Octostache.Tests
                 {
                     { "Greeting", "Hello world" },
                     { "Result", "result" },
+                });
+
+            result.Should().Be(template);
+        }
+
+        [Fact]
+        public void UnknownVariablesAsFunctionArgumentsAreEchoed()
+        {
+            const string template = "#{if Greeting | TpUpper}#{Result}#{/if}";
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "Result", "result" },
+                    { "MyVar", "Value" },
                 });
 
             result.Should().Be(template);


### PR DESCRIPTION
## Background

In release `3.2.0`, we enabled filter functions to be used inside condition expressions. When introducing this feature, we inadvertently broke backward compatibility when unknown variables are referenced in the conditionals.

Before introducing the feature (release <= `3.1.0`), when evaluating this expression
```
#{if UnknownVariable}Some words#{/if}
```
an empty string (`""`) will be returned as the result if there isn't a variable called `UnknownVariable` defined. Effectively, unknown variables are treated as empty strings. For this reason, this expression
```
#{if Unknown1 == Unknown2}Equal!#{/if}
```
will evaluate to `Equal!` when both variables are not defined.

In `3.2.0`, this behaviour has changed. When a variable is not defined, the evaluation will fail, and the original template will be returned. So, `#{if UnknownVariable}Some words#{/if}` is no longer able to be processed, and will be treated as a non-template, and returned verbatim.

## Result

This PR makes sure that the behaviour in conditional expressions is kept the same as in version `3.1.0` for backward compatibility. Unit tests were also added to document these behaviour.