### PR TITLE
Add support for calculations

### DIFF
--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Octostache.Tests
+{
+    public class CalculationFixture : BaseFixture
+    {
+        [Theory]
+        [InlineData("3+2", "5")]
+        [InlineData("3-2", "1")]
+        [InlineData("3*2", "6")]
+        [InlineData("3/2", "1,5")]
+        [InlineData("3*2+2*4", "14")]
+        [InlineData("3*(2+2)*4", "48")]
+        [InlineData("A+2", "7")]
+        [InlineData("A+B", "12")]
+        [InlineData("C+2", "#{C+2}")]
+        public void ConditionalIsSupported(string expression, string expectedResult)
+        {
+            var result = Evaluate($"#{{calc {expression}}}",
+                new Dictionary<string, string>
+                {
+                    { "A", "5" },
+                    { "B", "7" },
+                });
+
+            result.Should().Be(expectedResult);
+        }
+    }
+}

--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using FluentAssertions;
 using Xunit;
 
@@ -8,15 +9,7 @@ namespace Octostache.Tests
     public class CalculationFixture : BaseFixture
     {
         [Theory]
-        [InlineData("3+2", "5")]
-        [InlineData("3-2", "1")]
-        [InlineData("3*2", "6")]
-        [InlineData("3/2", "1,5")]
-        [InlineData("3*2+2*4", "14")]
-        [InlineData("3*(2+2)*4", "48")]
-        [InlineData("A+2", "7")]
-        [InlineData("A+B", "12")]
-        [InlineData("C+2", "#{C+2}")]
+        [MemberData(nameof(ConditionalIsSupportedData))]
         public void ConditionalIsSupported(string expression, string expectedResult)
         {
             var result = Evaluate($"#{{calc {expression}}}",
@@ -27,6 +20,19 @@ namespace Octostache.Tests
                 });
 
             result.Should().Be(expectedResult);
+        }
+
+        public static IEnumerable<object[]> ConditionalIsSupportedData()
+        {
+            yield return new object[] { "3+2", "5" };
+            yield return new object[] { "3-2", "1" };
+            yield return new object[] { "3*2", "6" };
+            yield return new object[] { "3/2", (3d / 2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "3*2+2*4", "14" };
+            yield return new object[] { "3*(2+2)*4", "48" };
+            yield return new object[] { "A+2", "7" };
+            yield return new object[] { "A+B", "12" };
+            yield return new object[] { "C+2", "#{C+2}" };
         }
     }
 }

--- a/source/Octostache/Templates/CalculationToken.cs
+++ b/source/Octostache/Templates/CalculationToken.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Octostache.Templates
+{
+    class CalculationToken : TemplateToken
+    {
+        public ICalculationComponent Expression { get; }
+
+        public CalculationToken(ICalculationComponent expression)
+        {
+            Expression = expression;
+        }
+
+        public override string ToString() => "#{" + Expression + "}";
+
+        public override IEnumerable<string> GetArguments() => Expression.GetArguments();
+    }
+
+    class CalculationConstant : ICalculationComponent
+    {
+        public double Value { get; }
+
+        public CalculationConstant(double value)
+        {
+            Value = value;
+        }
+
+        public double? Evaluate(Func<SymbolExpression, string?> resolve) => Value;
+
+        public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+
+        public IEnumerable<string> GetArguments()
+        {
+            yield break;
+        }
+    }
+
+    class CalculationVariable : ICalculationComponent
+    {
+        public SymbolExpression Variable { get; }
+
+        public CalculationVariable(SymbolExpression variable)
+        {
+            Variable = variable;
+        }
+
+        public double? Evaluate(Func<SymbolExpression, string?> resolve)
+        {
+            var stringValue = resolve(Variable);
+
+            if (stringValue == null)
+                return null;
+
+            if (!double.TryParse(stringValue, out var value))
+                return null;
+
+            return value;
+        }
+
+        public override string ToString() => Variable.ToString();
+
+        public IEnumerable<string> GetArguments() => Variable.GetArguments();
+    }
+
+    class CalculationOperation : ICalculationComponent
+    {
+        public ICalculationComponent Left { get; }
+        public CalculationOperator Op { get; }
+        public ICalculationComponent Right { get; }
+
+        public CalculationOperation(ICalculationComponent left, CalculationOperator op, ICalculationComponent right)
+        {
+            Left = left;
+            Op = op;
+            Right = right;
+        }
+
+        string OperatorAsString =>
+            Op switch
+            {
+                CalculationOperator.Add => "+",
+                CalculationOperator.Subtract => "-",
+                CalculationOperator.Multiply => "*",
+                CalculationOperator.Divide => "/",
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+
+        public double? Evaluate(Func<SymbolExpression, string?> resolve)
+        {
+            var leftValue = Left.Evaluate(resolve);
+            if (leftValue == null)
+                return null;
+
+            var rightValue = Right.Evaluate(resolve);
+            if (rightValue == null)
+                return null;
+
+            return Op switch
+            {
+                CalculationOperator.Add => leftValue + rightValue,
+                CalculationOperator.Subtract => leftValue - rightValue,
+                CalculationOperator.Multiply => leftValue * rightValue,
+                CalculationOperator.Divide => leftValue / rightValue,
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+        }
+
+        public IEnumerable<string> GetArguments() => Left.GetArguments().Concat(Right.GetArguments());
+
+        public override string ToString() => $"{Left}{OperatorAsString}{Right}";
+    }
+
+    interface ICalculationComponent
+    {
+        double? Evaluate(Func<SymbolExpression, string?> resolve);
+        IEnumerable<string> GetArguments();
+    }
+
+    enum CalculationOperator
+    {
+        Add,
+        Subtract,
+        Multiply,
+        Divide,
+    }
+}

--- a/source/Octostache/Templates/TemplateEvaluator.cs
+++ b/source/Octostache/Templates/TemplateEvaluator.cs
@@ -71,6 +71,24 @@ namespace Octostache.Templates
                 return;
             }
 
+            var cat = token as CalculationToken;
+            if (cat != null)
+            {
+                var value = cat.Expression.Evaluate(s =>
+                {
+                    var value = context.ResolveOptional(s, out var innerTokens);
+                    missingTokens.AddRange(innerTokens);
+                    return value;
+                });
+
+                if (value != null)
+                    context.Output.Write(value);
+                else
+                    context.Output.Write(cat.ToString());
+
+                return;
+            }
+
             throw new NotImplementedException("Unknown token type: " + token);
         }
 


### PR DESCRIPTION
Hi!

I thought it might be useful to have support for calculating values in Octopus.

One of the use cases we had in our own team was that we wanted to define an IP range per project but the actual IP via tenant. Currently we have a project variable "IP.Prefix" (e.g. `192.168.0`) and a tenant variable "IP.Suffix" (e.g. `5`) and they will be appended. However it would be easier for us to just have an "IP" project variable (e.g. `192.168.0.#{calc 10 + IP.Offset}`) and a "IP.Offset" variable in the tenants.

There are probably a multitude of other use cases for mathematical calculations.

For now the supported operators are only `+`, `-`, `/`, `*` but this could be extended quite easily.