### PR TITLE
Revert "Disable Dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/source/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Pacific/Auckland"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Dependabot for this repository has been disabled in the past by #85.

TSO has confirmed we're good to re-enable them. We don't do auto-merges, so it should be good.
See our [(internal) slack thread](https://octopusdeploy.slack.com/archives/C025P7WQ3G9/p1659573742554489?thread_ts=1659519920.759639&cid=C025P7WQ3G9) for more info.

Reverts OctopusDeploy/Octostache#85