### PR TITLE
Fix build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "5.12.0",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,6 @@
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
-#tool "dotnet:?package=GitVersion.Tool&version=5.3.6"
 #tool "nuget:?package=OctopusTools&version=9.0.0"
 #addin nuget:?package=Cake.Git&version=1.1.0
 

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,7 @@ Setup(context =>
 {
     gitVersionInfo = GitVersion(new GitVersionSettings {
         OutputType = GitVersionOutput.Json,
-        ToolPath = new FilePath("$HOME/.nuget/packages/gitversion.tool")
+        ToolPath = new FilePath("C:\Users\ContainerAdministrator\.nuget\packages\gitversion.tool")
     });
 
     nugetVersion = gitVersionInfo.NuGetVersion;

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,7 @@ Setup(context =>
 {
     gitVersionInfo = GitVersion(new GitVersionSettings {
         OutputType = GitVersionOutput.Json,
-        ToolPath = new FilePath("C:/Users/ContainerAdministrator/.nuget/packages/gitversion.tool")
+        ToolPath = new FilePath("C:/Users/ContainerAdministrator/.nuget/packages/gitversion.tool/5.12.0/gitversion.tool.5.12.0.nupkg")
     });
 
     nugetVersion = gitVersionInfo.NuGetVersion;

--- a/build.cake
+++ b/build.cake
@@ -28,7 +28,7 @@ Setup(context =>
 {
     gitVersionInfo = GitVersion(new GitVersionSettings {
         OutputType = GitVersionOutput.Json,
-        ToolPath = new FilePath("C:\Users\ContainerAdministrator\.nuget\packages\gitversion.tool")
+        ToolPath = new FilePath("C:/Users/ContainerAdministrator/.nuget/packages/gitversion.tool")
     });
 
     nugetVersion = gitVersionInfo.NuGetVersion;

--- a/build.cake
+++ b/build.cake
@@ -27,7 +27,8 @@ string nugetVersion;
 Setup(context =>
 {
     gitVersionInfo = GitVersion(new GitVersionSettings {
-        OutputType = GitVersionOutput.Json
+        OutputType = GitVersionOutput.Json,
+        ToolPath = new FilePath("$HOME/.nuget/packages/gitversion.tool")
     });
 
     nugetVersion = gitVersionInfo.NuGetVersion;

--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
+#tool "dotnet:?package=GitVersion.Tool&version=5.12.0"
 #tool "nuget:?package=OctopusTools&version=9.0.0"
 #addin nuget:?package=Cake.Git&version=1.1.0
 
@@ -27,8 +28,7 @@ string nugetVersion;
 Setup(context =>
 {
     gitVersionInfo = GitVersion(new GitVersionSettings {
-        OutputType = GitVersionOutput.Json,
-        ToolPath = new FilePath("C:/Users/ContainerAdministrator/.nuget/packages/gitversion.tool/5.12.0/gitversion.tool.5.12.0.nupkg")
+        OutputType = GitVersionOutput.Json
     });
 
     nugetVersion = gitVersionInfo.NuGetVersion;

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+      "version": "6.0.300",
+      "rollForward": "latestFeature",
+      "allowPrerelease": false
+    }
+  }

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -1360,6 +1360,7 @@ namespace Octostache.Tests
 
         class TestDocument
         {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
             public string Key { get; set; }
         }
     }

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -17,21 +17,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Octostache\Octostache.csproj"/>
+        <ProjectReference Include="..\Octostache\Octostache.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="4.19.2"/>
+        <PackageReference Include="FluentAssertions" Version="4.19.2" />
         <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2"/>
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1"/>
-        <PackageReference Include="Sprache" Version="2.1.0"/>
-        <PackageReference Include="xunit" Version="2.3.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1"/>
-        <PackageReference Include="YamlDotNet" Version="8.1.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Sprache" Version="2.1.0" />
+        <PackageReference Include="xunit" Version="2.3.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+        <PackageReference Include="YamlDotNet" Version="8.1.2" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
@@ -39,11 +39,11 @@
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-        <Reference Include="System.Runtime.Caching"/>
+        <Reference Include="System.Runtime.Caching" />
     </ItemGroup>
 
     <ItemGroup>
-        <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}"/>
+        <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>
 
 </Project>

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <VersionPrefix>0.0.0</VersionPrefix>
-        <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+        <TargetFrameworks>net6.0;net452</TargetFrameworks>
         <AssemblyName>Octostache.Tests</AssemblyName>
         <PackageId>Octostache.Tests</PackageId>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -35,20 +35,20 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1"/>
-        <PackageReference Include="Octopus.Versioning" Version="5.1.155"/>
-        <PackageReference Include="Sprache" Version="2.1.0"/>
-        <PackageReference Include="Markdig" Version="0.10.4"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
+        <PackageReference Include="Sprache" Version="2.1.0" />
+        <PackageReference Include="Markdig" Version="0.10.4" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-        <Reference Include="System.Runtime.Caching"/>
-        <Reference Include="System"/>
-        <Reference Include="Microsoft.CSharp"/>
+        <Reference Include="System.Runtime.Caching" />
+        <Reference Include="System" />
+        <Reference Include="Microsoft.CSharp" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Summary of changes:

- Added a `dotnet-tools.json` for installing and invoking tools
- Added a `global.json` to specify sdk version
- Minimal changes to drop net3.1 support and add net6.0 support, _for tests only_

Rest of the changes are already in TC.

When possible we should still convert to nuke, which there's already an old [PR](https://github.com/OctopusDeploy/Octostache/pull/63) for.