### PR TITLE
Fixes issue where the calc operation treats multiply as whole numbers…

### DIFF
--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -33,6 +33,16 @@ namespace Octostache.Tests
             yield return new object[] { "A+2", "7" };
             yield return new object[] { "A+B", "12" };
             yield return new object[] { "C+2", "#{C+2}" };
+            // In the TemplateParser.cs for Identifier and IdentifierWithoutWhitespace we include / and - as part of the identifier.
+            // There isn't a clean fix for this, but exlcuding these in the context of a calc operation would resolve this issue (and introduce problems for variables using - and / in calc operations).
+            //yield return new object[] { "B-2", "5" };
+            yield return new object[] { "2-B", "-5" };
+            yield return new object[] { "(B*2)-2", "12" };
+            yield return new object[] { "2-(B*2)", "-12" };
+            //yield return new object[] { "B/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "2/B", (2d / 7).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "0.2*B", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "B*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
         }
     }
 }

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -140,7 +140,7 @@ namespace Octostache.Templates
             .WithPosition();
 
         static readonly Parser<ICalculationComponent> CalculationConstant =
-            from number in Parse.Number.Select(double.Parse)
+            from number in Parse.Decimal.Select(double.Parse)
             select new CalculationConstant(number);
 
         static readonly Parser<ICalculationComponent> CalculationVariable =


### PR DESCRIPTION
Fixes issue where the calc operation treats multiply as whole number. Note using divide and minus currently fails when the variable comes before the operator. This is due to the template parser including these tokens as a part of identifiers and still requires a fix.