### PR TITLE
Fix #{calc variable/2}

### DIFF
--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -39,7 +39,7 @@ namespace Octostache.Tests
             yield return new object[] { "2-B", "-5" };
             yield return new object[] { "(B*2)-2", "12" };
             yield return new object[] { "2-(B*2)", "-12" };
-            //yield return new object[] { "B/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "B/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "2/B", (2d / 7).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "0.2*B", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "B*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -91,7 +91,7 @@ namespace Octostache.Templates
             .WithPosition();
         
         
-        static readonly Parser<SymbolExpression> TrentsSymbol =
+        static readonly Parser<SymbolExpression> SymbolWithoutSlash =
             (from first in MathematicalIdentifier
                 from rest in TrailingStep.Many()
                 select new SymbolExpression(new[] { first }.Concat(rest)))
@@ -162,7 +162,7 @@ namespace Octostache.Templates
             select new CalculationConstant(number);
 
         static readonly Parser<ICalculationComponent> CalculationVariable =
-            from symbol in TrentsSymbol.Token()
+            from symbol in SymbolWithoutSlash.Token()
             select new CalculationVariable(symbol);
 
         static readonly Parser<ICalculationComponent> CalculationValue =

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -79,7 +79,25 @@ namespace Octostache.Templates
         static readonly Parser<SymbolExpressionStep> TrailingStep =
             Parse.Char('.').Then(_ => Identifier).Select(i => (SymbolExpressionStep) i)
                 .XOr(Indexer);
-
+            
+        static readonly Parser<Identifier> MathematicalIdentifier = Parse
+            .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '~' || c == '(' || c == ')', "identifier")
+            .Except(Parse.WhiteSpace.FollowedBy("|"))
+            .Except(Parse.WhiteSpace.FollowedBy("}"))
+            .ExceptWhiteSpaceBeforeKeyword()
+            .AtLeastOnce()
+            .Text()
+            .Select(s => new Identifier(s.Trim()))
+            .WithPosition();
+        
+        
+        static readonly Parser<SymbolExpression> TrentsSymbol =
+            (from first in MathematicalIdentifier
+                from rest in TrailingStep.Many()
+                select new SymbolExpression(new[] { first }.Concat(rest)))
+            .WithPosition();
+        
+        
         static readonly Parser<SymbolExpression> Symbol =
             (from first in Identifier
                 from rest in TrailingStep.Many()
@@ -144,7 +162,7 @@ namespace Octostache.Templates
             select new CalculationConstant(number);
 
         static readonly Parser<ICalculationComponent> CalculationVariable =
-            from symbol in Symbol.Token()
+            from symbol in TrentsSymbol.Token()
             select new CalculationVariable(symbol);
 
         static readonly Parser<ICalculationComponent> CalculationValue =

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -79,7 +79,7 @@ namespace Octostache.Templates
         static readonly Parser<SymbolExpressionStep> TrailingStep =
             Parse.Char('.').Then(_ => Identifier).Select(i => (SymbolExpressionStep) i)
                 .XOr(Indexer);
-            
+
         static readonly Parser<Identifier> MathematicalIdentifier = Parse
             .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '~' || c == '(' || c == ')', "identifier")
             .Except(Parse.WhiteSpace.FollowedBy("|"))
@@ -89,15 +89,13 @@ namespace Octostache.Templates
             .Text()
             .Select(s => new Identifier(s.Trim()))
             .WithPosition();
-        
-        
+
         static readonly Parser<SymbolExpression> SymbolWithoutSlash =
             (from first in MathematicalIdentifier
                 from rest in TrailingStep.Many()
                 select new SymbolExpression(new[] { first }.Concat(rest)))
             .WithPosition();
-        
-        
+
         static readonly Parser<SymbolExpression> Symbol =
             (from first in Identifier
                 from rest in TrailingStep.Many()

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -159,6 +159,13 @@ namespace Octostache.Templates
             from number in Parse.Decimal.Select(double.Parse)
             select new CalculationConstant(number);
 
+        // NOTE: The "/" symbol is currently 2 things in octostache:
+        // 1. A valid character in a variable identifier
+        // 2. The division operator
+        // Thus, when parsing #{calc B/2} - how should the "/" be interpreted?
+        // Currently, it is being _forced_ as a divide - thus, variables containing
+        // a "/" character will _not_ be correctly parsed when used in a calc block.
+        // This decision maximised utility, with minimal change.
         static readonly Parser<ICalculationComponent> CalculationVariable =
             from symbol in SymbolWithoutSlash.Token()
             select new CalculationVariable(symbol);


### PR DESCRIPTION
#{calc var/2} currently fails, as the "/" (and the 2) is deemed to be part of the identifier (called "var/2").

To resolve this, the "/" needs to appear to be a delimiter, rather than part of the symbol.
I.e. at the moment "/" is both an OPERATOR and also an IDENTIFIER.

This fix is _nasty_ as it forces the "/" to be removed from the variable - however, given "hello/there" is a valid variable name according to octostache, this solution will not work for all situations. (i.e. is hello/there dividing hello by there, or is hello/there a variable name?).

The right solution is _probably_ to force delimiters around the variable name such that this problem goes away (and we can be clear as to the "/" symbols meaning.
