### PR TITLE
Calc variable substitution - Wrap rhs Variables with {}

### DIFF
--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -17,6 +17,8 @@ namespace Octostache.Tests
                 {
                     { "A", "5" },
                     { "B", "7" },
+                    { "The/Var", "9" },
+                    { "Another-Var", "11" },
                 });
 
             result.Should().Be(expectedResult);
@@ -35,12 +37,18 @@ namespace Octostache.Tests
             yield return new object[] { "C+2", "#{C+2}" };
             yield return new object[] { "{B}-2", "5" };
             yield return new object[] { "2-B", "-5" };
+            yield return new object[] { "2-4", "-2" };
             yield return new object[] { "(B*2)-2", "12" };
             yield return new object[] { "2-(B*2)", "-12" };
             yield return new object[] { "{B}/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "2/B", (2d / 7).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "2/{B}", (2d / 7).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "2/4", "0.5" };
             yield return new object[] { "0.2*B", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "B*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "{B}*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "{Another-Var}-2", "9" };
+            yield return new object[] { "{The/Var}-2", "7" };
 
             //erroneous parsing - variables as rhs operands must be surrounded with "{ ... }" to calc correctly.
             yield return new object[] { "B-2", "#{B-2}" };

--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -8,17 +8,17 @@ namespace Octostache.Tests
 {
     public class CalculationFixture : BaseFixture
     {
+        readonly Dictionary<string, string> variables = new Dictionary<string, string>
+        {
+            { "A", "5" },
+            { "B", "7" }
+        };
+
         [Theory]
         [MemberData(nameof(ConditionalIsSupportedData))]
         public void ConditionalIsSupported(string expression, string expectedResult)
         {
-            var result = Evaluate($"#{{calc {expression}}}",
-                new Dictionary<string, string>
-                {
-                    { "A", "5" },
-                    { "B", "7" },
-                });
-
+            var result = Evaluate($"#{{calc {expression}}}", variables);
             result.Should().Be(expectedResult);
         }
 
@@ -33,16 +33,18 @@ namespace Octostache.Tests
             yield return new object[] { "A+2", "7" };
             yield return new object[] { "A+B", "12" };
             yield return new object[] { "C+2", "#{C+2}" };
-            // In the TemplateParser.cs for Identifier and IdentifierWithoutWhitespace we include / and - as part of the identifier.
-            // There isn't a clean fix for this, but exlcuding these in the context of a calc operation would resolve this issue (and introduce problems for variables using - and / in calc operations).
-            //yield return new object[] { "B-2", "5" };
+            yield return new object[] { "{B}-2", "5" };
             yield return new object[] { "2-B", "-5" };
             yield return new object[] { "(B*2)-2", "12" };
             yield return new object[] { "2-(B*2)", "-12" };
-            yield return new object[] { "B/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
+            yield return new object[] { "{B}/2", (7d / 2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "2/B", (2d / 7).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "0.2*B", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "B*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
+            
+            //erroneous parsing - variables as rhs operands must be surrounded with "{ ... }" to calc correctly.
+            yield return new object[] { "B-2", "#{B-2}" };
+            yield return new object[] { "B/2", "#{B/2}" };
         }
     }
 }

--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -8,17 +8,17 @@ namespace Octostache.Tests
 {
     public class CalculationFixture : BaseFixture
     {
-        readonly Dictionary<string, string> variables = new Dictionary<string, string>
-        {
-            { "A", "5" },
-            { "B", "7" }
-        };
-
         [Theory]
         [MemberData(nameof(ConditionalIsSupportedData))]
         public void ConditionalIsSupported(string expression, string expectedResult)
         {
-            var result = Evaluate($"#{{calc {expression}}}", variables);
+            var result = Evaluate($"#{{calc {expression}}}",
+                new Dictionary<string, string>
+                {
+                    { "A", "5" },
+                    { "B", "7" },
+                });
+
             result.Should().Be(expectedResult);
         }
 

--- a/source/Octostache.Tests/CalculationFixture.cs
+++ b/source/Octostache.Tests/CalculationFixture.cs
@@ -41,7 +41,7 @@ namespace Octostache.Tests
             yield return new object[] { "2/B", (2d / 7).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "0.2*B", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
             yield return new object[] { "B*0.2", (7d * 0.2).ToString(CultureInfo.CurrentCulture) };
-            
+
             //erroneous parsing - variables as rhs operands must be surrounded with "{ ... }" to calc correctly.
             yield return new object[] { "B-2", "#{B-2}" };
             yield return new object[] { "B/2", "#{B/2}" };

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -79,7 +79,7 @@ namespace Octostache.Templates
         static readonly Parser<SymbolExpressionStep> TrailingStep =
             Parse.Char('.').Then(_ => Identifier).Select(i => (SymbolExpressionStep) i)
                 .XOr(Indexer);
-        
+
         static readonly Parser<SymbolExpression> Symbol =
             (from first in Identifier
                 from rest in TrailingStep.Many()
@@ -143,7 +143,6 @@ namespace Octostache.Templates
             from number in Parse.Decimal.Select(double.Parse)
             select new CalculationConstant(number);
 
-
         // As "/" and "-" operators are also valid characters for identifiers - there are times people
         // may want to wrap their variable names inside a calc block to avoid operator conflict
         static readonly Parser<ICalculationComponent> WrappedCalculationVariable =
@@ -153,7 +152,7 @@ namespace Octostache.Templates
             from rsp in Parse.WhiteSpace.Many()
             from rightDelim in RDelim
             select new CalculationVariable(symbol);
-        
+
         static readonly Parser<ICalculationComponent> CalculationVariable =
             from symbol in Symbol.Token()
             select new CalculationVariable(symbol);

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -144,8 +144,8 @@ namespace Octostache.Templates
             select new CalculationConstant(number);
 
 
-        // As operators are also valid characters for identifiers - there are times people
-        // may want to wrap their variable names inside a calc block
+        // As "/" and "-" operators are also valid characters for identifiers - there are times people
+        // may want to wrap their variable names inside a calc block to avoid operator conflict
         static readonly Parser<ICalculationComponent> WrappedCalculationVariable =
             from leftDelim in Parse.String("{")
             from lsp in Parse.WhiteSpace.Many()


### PR DESCRIPTION
Currently, a calc operation automatically assumes that a "/" is an operator, rather than forming part of a variable name.

Thus #{calc My/Var / 2} would assume there are 2 operations: "My / Var", and "Var / 2", whereas the user may actually have a variable called "My/Var" and is intending for it to be halved.

To overcome this issue, and allow any/all variables to be used in a calc operation, it has been decided to allow a variable to be wrapped in "{ ... }" marks, in order to guarantee expected operation.
eg: `#{calc {My/Var}/2}`

Un-wrapped variable names will continue to work as current behaviour.

Eg: `#{calc MyVar * 2}` will continue to work as expected, and does not _require_ "{...}" (but would work if wrapping existed.)
i.e. `#{calc {MyVar} * 2}` is considered legal syntax.



