### PR TITLE
Cleanup

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.300",
+      "version": "8.0.100",
       "rollForward": "latestFeature",
       "allowPrerelease": false
     }

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -26,7 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Sprache" Version="2.1.0" />
         <PackageReference Include="xunit" Version="2.3.1" />

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -30,10 +30,6 @@
         <PackageReference Include="YamlDotNet" Version="8.1.2" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-        <Reference Include="System.Runtime.Caching" />
-    </ItemGroup>
-
     <ItemGroup>
         <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -34,10 +34,6 @@
         <PackageReference Include="YamlDotNet" Version="8.1.2" />
     </ItemGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-        <DefineConstants>$(DefineConstants);NET40</DefineConstants>
-    </PropertyGroup>
-
     <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
         <Reference Include="System.Runtime.Caching" />
     </ItemGroup>

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <VersionPrefix>0.0.0</VersionPrefix>
-        <TargetFrameworks>net6.0;net452</TargetFrameworks>
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
         <AssemblyName>Octostache.Tests</AssemblyName>
         <PackageId>Octostache.Tests</PackageId>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="FluentAssertions" Version="4.19.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Sprache" Version="2.1.0" />
+        <PackageReference Include="Sprache" Version="2.3.1" />
         <PackageReference Include="xunit" Version="2.6.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="all" />
         <PackageReference Include="YamlDotNet" Version="8.1.2" />

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Sprache" Version="2.1.0" />
-        <PackageReference Include="xunit" Version="2.3.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="all" />
         <PackageReference Include="YamlDotNet" Version="8.1.2" />
     </ItemGroup>
 

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -22,10 +22,6 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="4.19.2" />
-        <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Sprache" Version="2.1.0" />

--- a/source/Octostache.sln
+++ b/source/Octostache.sln
@@ -6,6 +6,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octostache", "Octostache\Oc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octostache.Tests", "Octostache.Tests\Octostache.Tests.csproj", "{31E68EAE-742C-4FA5-9C63-FE50F7D269D3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{8BE71604-F713-42B2-B067-E9E2FA42E261}"
+	ProjectSection(SolutionItems) = preProject
+		..\global.json = ..\global.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -35,7 +35,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
         <PackageReference Include="Sprache" Version="2.1.0" />
         <PackageReference Include="Markdig" Version="0.10.4" />

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -32,8 +32,8 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
         <PackageReference Include="Markdig" Version="0.10.4" />
+        <PackageReference Include="Octopus.Versioning" Version="5.1.827" />
         <PackageReference Include="Sprache" Version="2.3.1" />
     </ItemGroup>
 

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -32,9 +32,9 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Markdig" Version="0.10.4" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.827" />
         <PackageReference Include="Sprache" Version="2.3.1" />
+        <PackageReference Include="Markdig" Version="0.33.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -5,7 +5,7 @@
         <NeutralLanguage>en-US</NeutralLanguage>
         <VersionPrefix>0.0.0</VersionPrefix>
         <Authors>Octopus Deploy</Authors>
-        <TargetFrameworks>netstandard2.1;net40</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
         <AssemblyName>Octostache</AssemblyName>
         <PackageId>Octostache</PackageId>
         <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3-32x32.png</PackageIconUrl>
@@ -26,7 +26,7 @@
     <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
         <DefineConstants>$(DefineConstants);HAS_NULLABLE_REF_TYPES</DefineConstants>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetFramework)' == 'net40' ">
+    <PropertyGroup Condition="'$(TargetFramework)' == 'NET462' ">
         <NoWarn>CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
     </PropertyGroup>
 
@@ -41,7 +41,7 @@
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'NET462' ">
         <Reference Include="System.Runtime.Caching" />
         <Reference Include="System" />
         <Reference Include="Microsoft.CSharp" />

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -33,8 +33,8 @@
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
-        <PackageReference Include="Sprache" Version="2.1.0" />
         <PackageReference Include="Markdig" Version="0.10.4" />
+        <PackageReference Include="Sprache" Version="2.3.1" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -31,10 +31,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Octopus.Versioning" Version="5.1.155" />
         <PackageReference Include="Sprache" Version="2.1.0" />

--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'NET462' ">

--- a/source/Octostache/Templates/ItemCache.cs
+++ b/source/Octostache/Templates/ItemCache.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#if NET40
+#if NET462
 using System.Runtime.Caching;
 using System.Collections.Specialized;
 
@@ -30,7 +30,7 @@ namespace Octostache.Templates
             MegabyteLimit = megabyteLimit;
             SlidingExpiration = slidingExpiration;
 
-#if NET40
+#if NET462
             cache = new MemoryCache(Name,
                 new NameValueCollection
                     { { "CacheMemoryLimitMegabytes", MegabyteLimit.ToString() } });
@@ -42,7 +42,7 @@ namespace Octostache.Templates
         // ReSharper disable once MemberCanBePrivate.Global
         public void Add(string key, T? item)
         {
-#if NET40
+#if NET462
             cache.Set(key, item ?? nullItem, new CacheItemPolicy { SlidingExpiration = SlidingExpiration });
 #else
             // NOTE: Setting the size to the string length, is not quite right, but close enough for our purposes. 
@@ -70,7 +70,7 @@ namespace Octostache.Templates
 
         public void Clear()
         {
-#if NET40
+#if NET462
             cache = new MemoryCache(Name,
                 new NameValueCollection
                     { { "CacheMemoryLimitMegabytes", MegabyteLimit.ToString() } });

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Sprache;
 
-#if NET40
+#if NET462
 #else
 using System.Diagnostics.CodeAnalysis;
 #endif


### PR DESCRIPTION
I was getting some nasty nuget issues with conflicts between.

So this PR is an initial attempt to get Octostache onto the current stack of nugets, tfms, sdk, etc

this is a breaking change since it moves from net40 to net462, since that is required to update some refs

```

12:29:32| Warning As Error: Detected package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.Console 4.0.0 -> runtime.win.System.Console 4.3.1 -> System.IO.FileSystem.Primitives (>= 4.3.0)
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.IO.FileSystem.Primitives (>= 4.0.1)
12:29:32| Warning As Error: Detected package downgrade: System.Text.Encoding.Extensions from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version.
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.Console 4.0.0 -> runtime.win.System.Console 4.3.1 -> System.Text.Encoding.Extensions (>= 4.3.0)
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.Text.Encoding.Extensions (>= 4.0.11)
12:29:32| Warning As Error: Detected package downgrade: System.Diagnostics.Debug from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version.
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.IO.FileSystem 4.0.1 -> runtime.win.System.IO.FileSystem 4.3.0 -> System.Diagnostics.Debug (>= 4.3.0)
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.Diagnostics.Debug (>= 4.0.11)
12:29:32| Warning As Error: Detected package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.IO.FileSystem 4.0.1 -> runtime.win.System.IO.FileSystem 4.3.0 -> System.IO.FileSystem.Primitives (>= 4.3.0)
 ElectorateReporting.Api -> Octostache 3.7.0 -> Markdig 0.10.4 -> NETStandard.Library 1.6.0 -> System.IO.FileSystem.Primitives (>= 4.0.1)
 ```