### PR TITLE
Update SDK used to match what is used currently on build servers

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.100",
+      "version": "6.0.300",
       "rollForward": "latestFeature",
       "allowPrerelease": false
     }

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <VersionPrefix>0.0.0</VersionPrefix>
-        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+        <TargetFrameworks>net6.0;net48</TargetFrameworks>
         <AssemblyName>Octostache.Tests</AssemblyName>
         <PackageId>Octostache.Tests</PackageId>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
A previous PR changed this to taget net8. This is causing some issues in the build system which still relies on net6 so since this shouldn't affect the library itself being built, ive rolled the change back until we are more net8 across the board.