### PR TITLE
sdk 8.0.204 and add nuget CVE audit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.300",
+      "version": "8.0.204",
       "rollForward": "latestFeature",
       "allowPrerelease": false
     }


### PR DESCRIPTION
This PR is to show how Octostache will fail a CVE audit because it has a transitive reference to vunerable versions of System.Text.RegularExpressions and System.Net.Http

Can you please update to versions with no CVE so as to not force that change on all consumers

```
C:\Code\Octostache\source\Octostache\Octostache.csproj : error NU1903: Warning As Error: Package 'System.Text.RegularEx
pressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj [C:\Code\Oc
tostache\source\Octostache.sln]
  Failed to restore C:\Code\Octostache\source\Octostache\Octostache.csproj (in 22 sec).
C:\Code\Octostache\source\Octostache.Tests\Octostache.Tests.csproj : error NU1903: Warning As Error: Package 'System.Ne
t.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57 [C:\Code\Octos
tache\source\Octostache.sln]
C:\Code\Octostache\source\Octostache.Tests\Octostache.Tests.csproj : error NU1903: Warning As Error: Package 'System.Te
xt.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
 [C:\Code\Octostache\source\Octostache.sln]
```