### PR TITLE
Remove automatic suffix to Truncate function

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -646,7 +646,7 @@ namespace Octostache.Tests
             result.Should().Be("Octopus");
             result.Should().HaveLength(7);
         }
-        
+
         [Fact]
         public void TruncateTruncatesArgumentToSpecifiedLengthWithCustomSuffix()
         {

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -643,7 +643,16 @@ namespace Octostache.Tests
         public void TruncateTruncatesArgumentToSpecifiedLength()
         {
             var result = Evaluate(@"#{foo | Truncate 7}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
-            result.Should().Be("Octopus...");
+            result.Should().Be("Octopus");
+            result.Should().HaveLength(7);
+        }
+        
+        [Fact]
+        public void TruncateTruncatesArgumentToSpecifiedLengthWithCustomSuffix()
+        {
+            var result = Evaluate(@"#{foo | Truncate 7 ""<|>""}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
+            result.Should().Be("Octopus<|>");
+            result.Should().HaveLength(10);
         }
 
         [Fact]

--- a/source/Octostache/Templates/Functions/TextManipulationFunction.cs
+++ b/source/Octostache/Templates/Functions/TextManipulationFunction.cs
@@ -124,7 +124,6 @@ namespace Octostache.Templates.Functions
                 : argument;
         }
 
-
         [return: NotNullIfNotNull("argument")]
         public static string? Trim(string? argument, string[] options)
         {

--- a/source/Octostache/Templates/Functions/TextManipulationFunction.cs
+++ b/source/Octostache/Templates/Functions/TextManipulationFunction.cs
@@ -118,10 +118,12 @@ namespace Octostache.Templates.Functions
             }
 
             var length = int.Parse(options[0]);
+            var suffix = options.Length == 2 ? options[1] : null;
             return length < argument.Length
-                ? $"{argument.Substring(0, length)}..."
+                ? $"{argument.Substring(0, length)}{suffix}"
                 : argument;
         }
+
 
         [return: NotNullIfNotNull("argument")]
         public static string? Trim(string? argument, string[] options)


### PR DESCRIPTION
The `Truncate` function automatically applies a `...` suffix when the supplied string exceeds the specified length. While this is [documented](https://octopus.com/docs/projects/variables/variable-filters#truncate) appropriately, I think this is poor default behaviour.

It means that you can't truncate a long string and guarantee that the resulting string is the correct length. For instance, `#{abcdef | Truncate 3}` results in a 6 character long string `abc...`.

The only way to fix this is to _then_ perform a replace... so `#{abcdef | Truncate 3 | Replace "..." ""}` which seems counter intuitive.

This PR changes the truncate function to remove the default `...` suffix, but adds a second parameter to allow for a custom suffix to be specified if required.

e.g. `#{abcdef 3 "123"} results in `abc123`.

This is a breaking change to the Truncate function, so I'm not sure of the process for this. If we want to maintain the current behaviour but add support for _no_ suffix, we could change it so the 2nd parameter can be `""` to set no suffix, but my opinion is that no suffix by default would be desirable behaviour.

tl;dr: if I truncate a string, I expect the result to be equal to or less than the truncate length, not longer.

