### PR TITLE
Check bounds when indexing arrays

### DIFF
--- a/source/Octostache.Tests/JsonFixture.cs
+++ b/source/Octostache.Tests/JsonFixture.cs
@@ -92,6 +92,18 @@ namespace Octostache.Tests
         }
 
         [Fact]
+        public void JsonArrayOutsideOfBounds()
+        {
+            var variables = new VariableDictionary
+            {
+                ["Test"] = "[2,3,5,8]",
+            };
+
+            var pattern = "Alpha#{Test[4]}bet";
+            variables.Evaluate(pattern).Should().Be("Alphabet");
+        }
+
+        [Fact]
         public void JsonObjectSupportsIterator()
         {
             var variables = new VariableDictionary

--- a/source/Octostache/CustomStringParsers/JsonParser.cs
+++ b/source/Octostache/CustomStringParsers/JsonParser.cs
@@ -112,7 +112,9 @@ namespace Octostache.CustomStringParsers
             if (!int.TryParse(property, out index))
                 return false;
 
-            subBinding = ConvertJTokenToBinding(jarray[index]);
+            var value = index > 0 && index < jarray.Count ? jarray[index] : null;
+
+            subBinding = ConvertJTokenToBinding(value);
             return true;
         }
 


### PR DESCRIPTION
# Background

If an out-of-bounds index value is supplied when indexing into a JSON array, evaluation of the expression resulted in an exception. Generally Octostache does not throw exceptions for missing/invalid values when processing a template.

This pull request updates Octostache to handle indexes out of bounds by returning an empty string, which is consistent with the behaviour when handling missing JSON properties.

- Resolves #115

A unit test was added to validate this behaviour.
