### PR TITLE
Upgrade dependencies

### DIFF
--- a/source/Octostache/Octostache.csproj
+++ b/source/Octostache/Octostache.csproj
@@ -32,19 +32,19 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="Octopus.Versioning" Version="5.1.827"/>
+        <PackageReference Include="Octopus.Versioning" Version="5.1.882" />
         <PackageReference Include="Sprache" Version="2.3.1"/>
-        <PackageReference Include="Markdig" Version="0.33.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0"/>
+        <PackageReference Include="Markdig" Version="0.41.3" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'NET462' ">
         <Reference Include="System.Runtime.Caching"/>
         <Reference Include="System"/>
         <Reference Include="Microsoft.CSharp"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Apply the following updates:

- Markdig: 0.33.0 -> 0.41.3
- Microsoft.Extensions.Caching.Memory: 7.0.0 -> 8.0.1
- Octopus.Versioning: 5.1.827 -> 5.1.882

Resolves the following error in Markdown tests:

```
System.IO.FileLoadException : Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
     at System.MemoryExtensions.AsSpan(String text, Int32 start)
     at Markdig.Helpers.LineReader.ReadLine()
     at Markdig.Parsers.MarkdownParser.ProcessBlocks(BlockProcessor blockProcessor, LineReader lineReader)
     at Markdig.Parsers.MarkdownParser.Parse(String text, MarkdownPipeline pipeline, MarkdownParserContext context)
     at Markdig.Markdown.ToHtml(String markdown, MarkdownPipeline pipeline, MarkdownParserContext context)
     at Octostache.Templates.Functions.TextEscapeFunctions.MarkdownToHtml(String argument, String[] options) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\Functions\TextEscapeFunctions.cs:line 117
     at Octostache.Templates.BuiltInFunctions.InvokeOrNull(String function, String argument, String[] options) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\BuiltInFunctions.cs:line 64
     at Octostache.Templates.TemplateEvaluator.Calculate(ContentExpression expression, EvaluationContext context) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\TemplateEvaluator.cs:line 244
     at Octostache.Templates.TemplateEvaluator.EvaluateSubstitutionToken(EvaluationContext context, SubstitutionToken st) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\TemplateEvaluator.cs:line 200
     at Octostache.Templates.TemplateEvaluator.Evaluate(TemplateToken token, EvaluationContext context) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\TemplateEvaluator.cs:line 63
     at Octostache.Templates.TemplateEvaluator.Evaluate(IEnumerable`1 tokens, EvaluationContext context) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\TemplateEvaluator.cs:line 44
     at Octostache.Templates.TemplateEvaluator.Evaluate(Template template, EvaluationContext context, String[]& missingTokens, String[]& nullTokens) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\Templates\TemplateEvaluator.cs:line 15
     at Octostache.VariableDictionary.Evaluate(String expressionOrVariableOrText, String& error, Boolean haltOnError) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache\VariableDictionary.cs:line 176
     at Octostache.Tests.BaseFixture.Evaluate(String template, IDictionary`2 variables, Boolean haltOnError) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache.Tests\BaseFixture.cs:line 26
     at Octostache.Tests.FiltersFixture.MarkdownHttpLinkIsProcessed(String input, String value, String expectedResult) in C:\BuildAgent\work\5b4c0657ae01cb36\source\Octostache.Tests\FiltersFixture.cs:line 268
```
