### PR TITLE
Add octoversion config

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,0 +1,8 @@
+{
+  "NonPreReleaseTags": [
+    "refs/heads/main",
+    "refs/heads/master",
+    "main",
+    "master"
+  ]
+}


### PR DESCRIPTION
Adds an octoversion config file to configure branches that are not considered pre-release.

This means that master branch builds will be versioned as x.y.z rather than x.y.z-master