### PR TITLE
Fix net48 test host FileLoadException and move build tooling to net10

### DIFF
--- a/nuke-build/Build.cs
+++ b/nuke-build/Build.cs
@@ -26,7 +26,7 @@ class Build : NukeBuild
     [Parameter("Patch number override for OctoVersion")] readonly int? PatchNumberOverride;
 
     [OctoVersion(UpdateBuildNumber = true, BranchMember = nameof(BranchName), AutoDetectBranchMember = nameof(AutoDetectBranch), PatchMember = nameof(PatchNumberOverride),
-        Framework = "net9.0")]
+        Framework = "net10.0")]
     readonly OctoVersionInfo OctoVersionInfo;
 
     static AbsolutePath SourceDirectory => RootDirectory / "source";

--- a/nuke-build/_build.csproj
+++ b/nuke-build/_build.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!--
-    Build system is using net9.0 as tooling and SDK use net9.0
+    Build system is using net10.0 as tooling and SDK use net10.0
     The project itself still targets netstandard2.1 and net462
     This does not impact the framework used when running the tests
     -->
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
-    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.0.9]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.1.25]" />
   </ItemGroup>
 
 </Project>

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -22,6 +22,15 @@
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
+    <!-- On .NET Framework, Markdig transitively depends on System.Memory. Without
+         binding redirects the test host resolves a mismatched version and throws
+         System.IO.FileLoadException. Auto-generate the redirects into the test
+         assembly's config so the VSTest host unifies the versions at runtime. -->
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\Octostache\Octostache.csproj"/>
     </ItemGroup>

--- a/source/Octostache.Tests/app.config
+++ b/source/Octostache.Tests/app.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
-  <!-- Binding redirects are populated automatically at build time via
+    <!-- Binding redirects are populated automatically at build time via
        AutoGenerateBindingRedirects (see Octostache.Tests.csproj). This anchors
        the generated redirects so the .NET Framework (net48) test host unifies
        transitive dependencies such as System.Memory (pulled in by Markdig). -->
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/source/Octostache.Tests/app.config
+++ b/source/Octostache.Tests/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <!-- Binding redirects are populated automatically at build time via
        AutoGenerateBindingRedirects (see Octostache.Tests.csproj). This anchors

--- a/source/Octostache.Tests/app.config
+++ b/source/Octostache.Tests/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Binding redirects are populated automatically at build time via
+       AutoGenerateBindingRedirects (see Octostache.Tests.csproj). This anchors
+       the generated redirects so the .NET Framework (net48) test host unifies
+       transitive dependencies such as System.Memory (pulled in by Markdig). -->
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
## Background

Two related build problems on the `net48`/net10 boundary, fixed together.

**1. net48 test host `FileLoadException`.** Markdig pulls in `System.Memory` transitively, and on the .NET Framework (net48) VSTest host the mismatched `System.Memory` version is resolved without binding redirects, throwing:

```
System.IO.FileLoadException: Could not load file or assembly 'System.Memory, Version=...'
```

Enabling `AutoGenerateBindingRedirects` lets MSBuild unify the transitive versions, and an `app.config` anchors the generated redirects into the test assembly's config so the host picks them up at runtime.

**2. Nuke build tooling still on net9.0.** `global.json` pins the SDK to net10 (`10.0.102`), but the Nuke build project and OctoVersion still targeted `net9.0`. On CI agents that only carry the net10 runtime, the net9-targeted tooling can't start — so the build fails before it ever reaches the solution (and thus before the fix above even matters). This mirrors the net8→net10 bump done in [OctoNotesGitHubUpdater#476](https://github.com/OctopusDeploy/OctoNotesGitHubUpdater/pull/476).

## Results

- **net48 tests:** host now loads and runs — local run 590/591 passing, `FileLoadException` gone. The single failure (`ParserFixture.EvaluateLotsOfTimesWithSet`) is an unrelated, machine-load-sensitive perf assertion (expected <12s, hit 13.2s under load), not a load failure.
- **Build tooling:** `nuke-build` now targets `net10.0`, OctoVersion runs with `Framework = "net10.0"`, and `Octopus.OctoVersion.Tool` bumped `1.0.9 → 1.1.25`. The build tooling project compiles clean under net10 locally.

All app-code changes are gated behind `net48`; `net10.0` product output is untouched.

## How to review

Four files, all mechanical:
- `Octostache.Tests.csproj` + `app.config` — net48-only binding-redirect generation.
- `nuke-build/Build.cs` + `nuke-build/_build.csproj` — net9→net10 tooling bump.

Two things worth knowing so you don't chase them:
- The generated `Octostache.Tests.dll.config` comes out with an **empty** `assemblyBinding` block locally — MSBuild only writes explicit redirects when it detects a real conflict during the build. The runtime behaviour we care about (host loads + runs Markdig code without throwing) is confirmed by the full 591-test run regardless.
- I couldn't read the TeamCity log directly (MCP auth unavailable this session), so the build-tooling diagnosis is inferred from `global.json` + the reference PR rather than the raw failure. **The TeamCity build going green is the real proof point.**

## Reducing risk

- App-code changes are net48-scoped; net10 product build/tests untouched.
- Verified locally: `dotnet build -f net48` clean, `dotnet test -f net48` loads + runs all 591 tests, and `dotnet build nuke-build/_build.csproj` clean under net10 (OctoVersion Tool 1.1.25 resolves).
- Rollback is trivial — four small file reverts.
