### PR TITLE
Add AddHours and AddDays date filters

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -402,6 +402,112 @@ namespace Octostache.Tests
             result1.Should().Be(DateTimeOffset.Now.ToString("zz"));
         }
 
+        [Theory]
+        [InlineData("2", "2030-05-22 11:05:00")]
+        [InlineData("-2", "2030-05-22 07:05:00")]
+        [InlineData("0", "2030-05-22 09:05:00")]
+        [InlineData("\"1.5\"", "2030-05-22 10:35:00")]
+        [InlineData("24", "2030-05-23 09:05:00")]
+        public void AddHoursShiftsTheDate(string amount, string expected)
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            var result = Evaluate($"#{{Date | AddHours {amount} | Format \"yyyy-MM-dd HH:mm:ss\"}}", dict);
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("1", "2030-05-23 09:05:00")]
+        [InlineData("-1", "2030-05-21 09:05:00")]
+        [InlineData("10", "2030-06-01 09:05:00")] // rolls over the month
+        [InlineData("\"0.5\"", "2030-05-22 21:05:00")]
+        public void AddDaysShiftsTheDate(string amount, string expected)
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            var result = Evaluate($"#{{Date | AddDays {amount} | Format \"yyyy-MM-dd HH:mm:ss\"}}", dict);
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void AddDaysCanBeChainedWithAddHours()
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            var result = Evaluate("#{Date | AddDays 1 | AddHours 2 | Format \"yyyy-MM-dd HH:mm:ss\"}", dict);
+            result.Should().Be("2030-05-23 11:05:00");
+        }
+
+        [Fact]
+        public void AddHoursAmountCanComeFromAnotherVariable()
+        {
+            var dict = new Dictionary<string, string>
+            {
+                { "Date", "2030-05-22 09:05:00" },
+                { "ChangeWindowHours", "8" },
+            };
+
+            // Note: a nested substitution can't be followed by another filter in the same chain
+            // (a pre-existing parser limitation that applies equally to Format, Append and Truncate),
+            // so AddHours has to be the last filter when its amount comes from a variable.
+            var result = Evaluate("#{Date | AddHours #{ChangeWindowHours}}", dict);
+            result.Should().Be("2030-05-22T17:05:00.0000000");
+        }
+
+        [Fact]
+        public void AddHoursCanBeWrappedInAVariableToVaryTheAmount()
+        {
+            var dict = new Dictionary<string, string>
+            {
+                { "Date", "2030-05-22 09:05:00" },
+                { "EndDate", "#{Date | AddHours 8 | Format \"yyyy-MM-dd HH:mm:ss\"}" },
+            };
+
+            var result = Evaluate("#{EndDate}", dict);
+            result.Should().Be("2030-05-22 17:05:00");
+        }
+
+        [Fact]
+        public void AddHoursKeepsAnExplicitOffset()
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22T09:05:00+02:00" } };
+
+            var result = Evaluate("#{Date | AddHours 2}", dict);
+            result.Should().Be("2030-05-22T11:05:00.0000000+02:00");
+        }
+
+        [Fact]
+        public void AddHoursCanBeChainedOffNowDate()
+        {
+            var result = Evaluate("#{ | NowDate | AddHours 2}", new Dictionary<string, string>());
+            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now.AddHours(2), 60000);
+        }
+
+        [Fact]
+        public void AddHoursOnNowDateUtcStaysInUtc()
+        {
+            var result = Evaluate("#{ | NowDateUtc | AddHours 2 | Format DateTimeOffset zz}", new Dictionary<string, string>());
+            result.Should().Be("+00");
+        }
+
+        [Theory]
+        [InlineData("#{Date | AddHours}")] // no amount
+        [InlineData("#{Date | AddHours 2 3}")] // too many arguments
+        [InlineData("#{Date | AddHours abc}")] // amount isn't a number
+        [InlineData("#{Invalid | AddHours 2}")] // input isn't a date
+        [InlineData("#{ | AddHours 2}")] // no input at all
+        [InlineData("#{Date | AddDays}")]
+        [InlineData("#{Date | AddDays abc}")]
+        [InlineData("#{Invalid | AddDays 2}")]
+        public void DateAddFiltersWithUnusableInputAreEchoed(string template)
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" }, { "Invalid", "hello World" } };
+
+            var result = Evaluate(template, dict)
+                .Replace("\"", ""); // function parameters have quotes added when evaluated back to a string, so we need to remove them
+            result.Should().Be(template);
+        }
+
         [Fact]
         public void FiltersAreAppliedInOrder()
         {

--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -25,6 +25,8 @@ namespace Octostache.Templates
             { "markdowntohtml", TextEscapeFunctions.MarkdownToHtml },
             { "nowdate", DateFunction.NowDate },
             { "nowdateutc", DateFunction.NowDateUtc },
+            { "addhours", DateFunction.AddHours },
+            { "adddays", DateFunction.AddDays },
             { "format", FormatFunction.Format },
             { "match", TextComparisonFunctions.Match },
             { "replace", TextReplaceFunction.Replace },

--- a/source/Octostache/Templates/Functions/DateFunction.cs
+++ b/source/Octostache/Templates/Functions/DateFunction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Octostache.Templates.Functions
@@ -19,6 +20,39 @@ namespace Octostache.Templates.Functions
                 return null;
 
             return DateTime.UtcNow.ToString(options.Any() ? options[0] : "O");
+        }
+
+        public static string? AddHours(string? argument, string[] options) => AddTimeSpan(TimeSpan.FromHours, argument, options);
+
+        public static string? AddDays(string? argument, string[] options) => AddTimeSpan(TimeSpan.FromDays, argument, options);
+
+        static string? AddTimeSpan(Func<double, TimeSpan> toTimeSpan, string? argument, string[] options)
+        {
+            if (argument == null || options.Length != 1)
+                return null;
+
+            if (!double.TryParse(options[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var amount))
+                return null;
+
+            try
+            {
+                var offset = toTimeSpan(amount);
+
+                // Naive stays naive, UTC keeps its 'Z'
+                if (DateTime.TryParse(argument, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out var date)
+                    && date.Kind != DateTimeKind.Local)
+                    return (date + offset).ToString("O");
+
+                // An explicit offset is kept, not shifted to server-local
+                if (DateTimeOffset.TryParse(argument, out var dateOffset))
+                    return (dateOffset + offset).ToString("O");
+            }
+            catch
+            {
+                // Amount or result out of range
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Related PRs

Merge order: this PR first, then the package publishes, then Docs and Server. Calamari additionally needs its `Octostache 3.9.2` pin bumped, so it stays red until then.

| Repo | PR |
|---|---|
| Docs | OctopusDeploy/docs#3326 |
| Server | OctopusDeploy/OctopusDeploy#46148 |
| Calamari | OctopusDeploy/Calamari#2124 |

---

## Why

Raised private: [ticket](https://octopuscd.zendesk.com/agent/tickets/215987). 

That company drives ServiceNow change requests entirely from Octopus variables and need a change window of `start + 2 hours`. Deploy **fromOctopus UI** want to keep doing it this way.

## What

Two new date filters, `AddHours` and `AddDays`:

```
#{Octopus.Task.QueueTime | AddHours 2 | Format "yyyy-MM-dd HH:mm:ss"}
```

- Amounts can be negative (`AddHours -2`). Can also do quoted: (`AddHours "1.5"`)
- Unusable input (non-date, non-numeric amount, wrong argument count) returns null, so the token echoes unreplaced rather than silently producing a wrong date.

### Time zone handling

| Input shape | Behaviour |
|---|---|
| No offset (`2030-05-22 09:05:00`, `Octopus.Task.QueueTime`) | Stays naive |
| UTC (`…Z`, from `NowDateUtc`) | Stays UTC |
| Explicit offset (`…+02:00`) | Keeps `+02:00`, not converted to server-local |

## Tests

Additive change unlikely to impact anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)
