### PR TITLE
Add AddTimeSpan date filter

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -402,6 +402,87 @@ namespace Octostache.Tests
             result1.Should().Be(DateTimeOffset.Now.ToString("zz"));
         }
 
+        [Theory]
+        [InlineData("02:00:00", "2030-05-22 11:05:00")] // 2 hours
+        [InlineData("-02:00:00", "2030-05-22 07:05:00")] // 2 hours back
+        [InlineData("00:02:00", "2030-05-22 09:07:00")] // 2 minutes
+        [InlineData("00:00:30", "2030-05-22 09:05:30")] // 30 seconds
+        [InlineData("\"2.00:00:00\"", "2030-05-24 09:05:00")] // 2 days
+        [InlineData("\"2.12:00:00\"", "2030-05-24 21:05:00")] // 2.5 days, ie 60 hours
+        [InlineData("2", "2030-05-24 09:05:00")] // a bare number is days
+        public void AddTimeSpanShiftsTheDate(string offset, string expected)
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            var result = Evaluate($"#{{Date | AddTimeSpan {offset} | Format \"yyyy-MM-dd HH:mm:ss\"}}", dict);
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void AddTimeSpanLeadingFieldOverTwentyThreeIsDaysNotHours()
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            // The hours field only holds 0-23, so once the leading field exceeds that it is read as
+            // days: 48:00:00 is 48 days, not 48 hours. Pinned here because it is silent, not an error.
+            Evaluate("#{Date | AddTimeSpan 23:00:00 | Format \"yyyy-MM-dd HH:mm:ss\"}", dict)
+                .Should().Be("2030-05-23 08:05:00");
+
+            Evaluate("#{Date | AddTimeSpan 48:00:00 | Format \"yyyy-MM-dd HH:mm:ss\"}", dict)
+                .Should().Be("2030-07-09 09:05:00");
+        }
+
+        [Fact]
+        public void AddTimeSpanDayFormHasToBeQuoted()
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" } };
+
+            // '.' is not a valid character in an unquoted filter argument
+            Evaluate("#{Date | AddTimeSpan 2.00:00:00}", dict)
+                .Should().Be("#{Date | AddTimeSpan 2.00:00:00}");
+
+            Evaluate("#{Date | AddTimeSpan \"2.00:00:00\"}", dict)
+                .Should().Be("2030-05-24T09:05:00.0000000");
+        }
+
+        [Fact]
+        public void AddTimeSpanKeepsAnExplicitOffset()
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22T09:05:00+02:00" } };
+
+            var result = Evaluate("#{Date | AddTimeSpan 02:00:00}", dict);
+            result.Should().Be("2030-05-22T11:05:00.0000000+02:00");
+        }
+
+        [Fact]
+        public void AddTimeSpanCanBeChainedOffNowDate()
+        {
+            var result = Evaluate("#{ | NowDate | AddTimeSpan 02:00:00}", new Dictionary<string, string>());
+            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now.AddHours(2), 60000);
+        }
+
+        [Fact]
+        public void AddTimeSpanOnNowDateUtcStaysInUtc()
+        {
+            var result = Evaluate("#{ | NowDateUtc | AddTimeSpan 02:00:00 | Format DateTimeOffset zz}", new Dictionary<string, string>());
+            result.Should().Be("+00");
+        }
+
+        [Theory]
+        [InlineData("#{Date | AddTimeSpan}")] // no offset
+        [InlineData("#{Date | AddTimeSpan 02:00:00 03:00:00}")] // too many arguments
+        [InlineData("#{Date | AddTimeSpan abc}")] // offset isn't a TimeSpan
+        [InlineData("#{Invalid | AddTimeSpan 02:00:00}")] // input isn't a date
+        [InlineData("#{ | AddTimeSpan 02:00:00}")] // no input at all
+        public void AddTimeSpanWithUnusableInputIsEchoed(string template)
+        {
+            var dict = new Dictionary<string, string> { { "Date", "2030-05-22 09:05:00" }, { "Invalid", "hello World" } };
+
+            var result = Evaluate(template, dict)
+                .Replace("\"", ""); // function parameters have quotes added when evaluated back to a string, so we need to remove them
+            result.Should().Be(template);
+        }
+
         [Fact]
         public void FiltersAreAppliedInOrder()
         {

--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -25,6 +25,7 @@ namespace Octostache.Templates
             { "markdowntohtml", TextEscapeFunctions.MarkdownToHtml },
             { "nowdate", DateFunction.NowDate },
             { "nowdateutc", DateFunction.NowDateUtc },
+            { "addtimespan", DateFunction.AddTimeSpan },
             { "format", FormatFunction.Format },
             { "match", TextComparisonFunctions.Match },
             { "replace", TextReplaceFunction.Replace },

--- a/source/Octostache/Templates/Functions/DateFunction.cs
+++ b/source/Octostache/Templates/Functions/DateFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Octostache.Templates.Functions
@@ -19,6 +20,33 @@ namespace Octostache.Templates.Functions
                 return null;
 
             return DateTime.UtcNow.ToString(options.Any() ? options[0] : "O");
+        }
+
+        public static string? AddTimeSpan(string? argument, string[] options)
+        {
+            if (argument == null || options.Length != 1)
+                return null;
+
+            if (!TimeSpan.TryParse(options[0], CultureInfo.InvariantCulture, out var offset))
+                return null;
+
+            try
+            {
+                // Naive stays naive, UTC keeps its 'Z'
+                if (DateTime.TryParse(argument, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out var date)
+                    && date.Kind != DateTimeKind.Local)
+                    return (date + offset).ToString("O");
+
+                // An explicit offset is kept, not shifted to server-local
+                if (DateTimeOffset.TryParse(argument, out var dateOffset))
+                    return (dateOffset + offset).ToString("O");
+            }
+            catch
+            {
+                // Result out of range
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## All PRs in this change

Three variants of the same feature — pick one row, the other two get closed.

| Variant | Octostache | Docs | Server | Calamari |
|---|---|---|---|---|
| **A** · `AddHours` + `AddDays` | #124 | OctopusDeploy/docs#3326 | OctopusDeploy/OctopusDeploy#46148 | OctopusDeploy/Calamari#2124 |
| **B** ← this PR · `AddTimeSpan` only | #125 | OctopusDeploy/docs#3328 | OctopusDeploy/OctopusDeploy#46155 | OctopusDeploy/Calamari#2128 |
| **C** · all units + `AddTimeSpan` | #126 | OctopusDeploy/docs#3329 | OctopusDeploy/OctopusDeploy#46159 | OctopusDeploy/Calamari#2129 |

Merge order is the same for every variant: Octostache first, then the package publishes, then Docs and Server. Calamari additionally needs its `Octostache 3.9.2` pin bumped, so it stays red until then.

---

## What

One filter covering every unit, instead of separate `AddHours`/`AddDays`.

```
#{Octopus.Task.QueueTime | AddTimeSpan 02:00:00 | Format "yyyy-MM-dd HH:mm:ss"}
```

Format is `{days}.{hours}:{minutes}:{seconds}`, per .NET [TimeSpan.Parse](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.parse#remarks). The `{days}.` part is optional. Negatives work (`-02:00:00`).

Time zone shape is preserved: naive stays naive, UTC stays UTC, an explicit offset is kept rather than converted to server-local.

## What reviewers should look at

**`48:00:00` is 48 days, not 48 hours.** The `{hours}` field only holds 0–23; above that the leading field is re-read as `{days}` and the rest shift along:

| Time span | Reading | Actual shift |
|---|---|---|
| `23:00:00` | `{hours}:{minutes}:{seconds}` | 23 hours |
| `24:00:00` | `{days}:{hours}:{minutes}` | **24 days** |
| `24:01:02` | `{days}:{hours}:{minutes}` | **24 days, 1 hour, 2 min** — `02` is minutes, not seconds |

Silent: no exception, no unreplaced token. Inherent to the .NET format rather than introduced here, but adopting the format adopts the trap. Pinned by a test and given a warning callout in the docs.

Note also that the day form needs quoting (`.` isn't valid unquoted), so the dangerous form parses bare while the correct one needs quotes.

## Tests

608 passing — units, negatives, the 23→24 flip, quoting, offset preservation, chaining off `NowDate`/`NowDateUtc`, echo-on-bad-input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
