### PR TITLE
Fix GitVersion.BranchName resolving to "N/A" on non-PR builds

### DIFF
--- a/nuke-build/Build.cs
+++ b/nuke-build/Build.cs
@@ -47,15 +47,19 @@ class Build : NukeBuild
         .Executes(() =>
             {
                 // Provides backwards compatibility with expected GitVersion configuration
-                if (TeamCity.Instance.IsPullRequest)
-                {
-                    // Use the actual branch name for PR builds rather than pull/xxx
-                    TeamCity.Instance.SetConfigurationParameter("GitVersion.BranchName", TeamCity.Instance.PullRequestSourceBranch);
-                }
-                else
-                {
-                    TeamCity.Instance.SetConfigurationParameter("GitVersion.BranchName", BranchName);
-                }
+
+                // TeamCity supplies the pull request parameters as the literal "N/A" on builds that
+                // aren't from a pull request, which is enough for IsPullRequest to report true. Check
+                // the source branch is usable as well, otherwise master builds end up with a branch
+                // name of "N/A" and anything consuming it, such as Octopus create-release --gitRef,
+                // fails to resolve a git reference.
+                var pullRequestSourceBranch = TeamCity.Instance.PullRequestSourceBranch;
+                var isPullRequest = TeamCity.Instance.IsPullRequest
+                    && !string.IsNullOrWhiteSpace(pullRequestSourceBranch)
+                    && !pullRequestSourceBranch.Equals("N/A", StringComparison.OrdinalIgnoreCase);
+
+                // Use the actual branch name for PR builds rather than pull/xxx
+                TeamCity.Instance.SetConfigurationParameter("GitVersion.BranchName", isPullRequest ? pullRequestSourceBranch : BranchName);
 
                 TeamCity.Instance.SetConfigurationParameter("GitVersion.FullSemVer", FullSemVer);
                 TeamCity.Instance.SetConfigurationParameter("GitVersion.NuGetVersion", NuGetVersion);


### PR DESCRIPTION
## Why

Releases from `master` cannot be created. `Create Release` fails at the last step:

```
create-release ... --version 3.9.3 --gitRef N/A --packageVersion 3.9.3
Finding deployment process at git reference N/A...
No git resource with the name 'N/A' exists in the repository.
Error from Octopus Server (HTTP 404 NotFound)
```

The Octostache Octopus project is version controlled, so `create-release` needs a real git ref. It's being handed the string `N/A`.

## Root cause

TeamCity supplies the pull request parameters as the literal `"N/A"` on builds that aren't from a pull request. From a master build's resolved properties:

```
teamcity.pullRequest.number        = N/A
teamcity.pullRequest.source.branch = N/A
GitVersion.BranchName              = N/A
```

`TeamCity.IsPullRequest` sees a present, non-empty value and reports `true`, so `CalculateVersion` took the PR path and published `PullRequestSourceBranch` — `"N/A"` — as `GitVersion.BranchName`.

## Fix

Check the source branch is actually usable before treating a build as a pull request:

```csharp
var pullRequestSourceBranch = TeamCity.Instance.PullRequestSourceBranch;
var isPullRequest = TeamCity.Instance.IsPullRequest
    && !string.IsNullOrWhiteSpace(pullRequestSourceBranch)
    && !pullRequestSourceBranch.Equals("N/A", StringComparison.OrdinalIgnoreCase);

TeamCity.Instance.SetConfigurationParameter("GitVersion.BranchName", isPullRequest ? pullRequestSourceBranch : BranchName);
```

Master builds now fall back to `BranchName` (`OCTOVERSION_CurrentBranch`, ie `refs/heads/master`).

## Blast radius

**PR builds are unaffected** — they carry a real source branch, take the same path as before, and were already resolving correctly. That's why `Create Release` has been passing on PR branches (e.g. `3.9.2-pull-126`) while failing on every master build.

The alternative quick fix — pointing the step's Git ref at `%teamcity.build.branch%` — would fix master but break PRs, since that resolves to `pull/126` rather than a branch Octopus can find. Hence fixing it here instead.

## Verification

`dotnet build nuke-build/_build.csproj` — 0 errors. The behaviour itself only manifests under TeamCity, so it needs a master build to confirm end to end.

## Not covered here

Two related problems in the TeamCity config, out of scope for this repo change:

- `Push Build Info` and `Create Release` take their version from `%dep.…CaculateVersion.GitVersion.FullSemVer%` (counter-based, eg `3.9.1653`) while the package built is `3.9.3`. Those need to agree.
- `Tag Repository` isn't idempotent, so any re-run of a release fails once the tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)