### PR TITLE
Pass extensions to nested evaluation contexts

### DIFF
--- a/source/Octostache.Tests/ExtensionFixture.cs
+++ b/source/Octostache.Tests/ExtensionFixture.cs
@@ -35,6 +35,21 @@ namespace Octostache.Tests
             result.Should().Be("2-1-18");
         }
 
+        [Fact]
+        public void TestRecursiveCustomExtension()
+        {
+            var variables = new VariableDictionary();
+            variables.Add("Foo", "Bar");
+
+            variables.AddExtension("supercoolfunc", SuperCoolFunc);
+            variables.Add("Var1", "#{Foo|supercoolfunc}");
+            variables.Add("Var2", "#{Var1}");
+
+            var result = variables.Get("Var2");
+
+            result.Should().Be("2-1-18");
+        }
+
         public static string SuperCoolFunc(string argument, string[] options)
         {
             return string.Join("-", argument.Select(c => (char.ToUpper(c) - 64).ToString()));

--- a/source/Octostache/Templates/EvaluationContext.cs
+++ b/source/Octostache/Templates/EvaluationContext.cs
@@ -148,7 +148,7 @@ namespace Octostache.Templates
                 {
                     using (var x = new StringWriter())
                     {
-                        var context = new EvaluationContext(new Binding(), x, this);
+                        var context = new EvaluationContext(new Binding(), x, this, Extensions);
 
                         TemplateEvaluator.Evaluate(template, context, out missingTokens, out nullTokens);
                         x.Flush();


### PR DESCRIPTION
Fixes #109

## Problem

Custom extension functions registered via `AddExtension` stop working as soon as evaluation recurses into a variable whose value is itself a template.

```csharp
variables.Add("Foo", "Bar");
variables.AddExtension("supercoolfunc", SuperCoolFunc);
variables.Add("Var1", "#{Foo|supercoolfunc}");
variables.Add("Var2", "#{Var1}");

variables.Get("Var2"); // "#{Foo | supercoolfunc}" instead of "2-1-18"
```

`EvaluationContext.ParseTemplate` builds the child context without forwarding `Extensions`, so the nested evaluation has an empty extension dictionary and leaves the filter unresolved. The `parent` chain is passed, but extension lookup does not walk it.

## Fix

Forward `Extensions` when constructing the nested context — the fix suggested by the reporter.

## Tests

Added `ExtensionFixture.TestRecursiveCustomExtension`, which reproduces the issue. Verified it fails on `master` and passes with the change. Full suite green: 615 passed on net10.0.