### PR TITLE
Allow @ in variable and property names

### DIFF
--- a/source/Octostache.Tests/JsonFixture.cs
+++ b/source/Octostache.Tests/JsonFixture.cs
@@ -45,6 +45,8 @@ namespace Octostache.Tests
         [InlineData("{\"Items\": [{\"Name\": \"Toast\"}, {\"Name\": \"Bread\"}]}", "#{Test.Items[0].Name}", "Toast", "Arrays")]
         [InlineData("{\"Foo\": {\"Bar\":\"11\"}}", "#{Test.Foo}", "{\"Bar\":\"11\"}", "Raw JSON returned")]
         [InlineData("{Name: \"#{Test.Value}\", Desc: \"Monkey\", Value: 12}", "#{Test.Name}", "12", "Non-Direct inner JSON")]
+        [InlineData("{\"@type\": \"Widget\"}", "#{Test.@type}", "Widget", "Property name containing @")]
+        [InlineData("{\"@type\": \"Widget\"}", "#{Test[@type]}", "Widget", "Indexed property name containing @")]
         public void SuccessfulJsonParsing(string json, string pattern, string expectedResult, string testName)
         {
             var variables = new VariableDictionary

--- a/source/Octostache.Tests/UsageFixture.cs
+++ b/source/Octostache.Tests/UsageFixture.cs
@@ -100,6 +100,8 @@ namespace Octostache.Tests
         [InlineData("#{a/b}", "a/b=Foo", "Foo")]
         [InlineData("#{a~b}", "a~b=Foo", "Foo")]
         [InlineData("#{(abc)}", "(abc)=Foo", "Foo")]
+        [InlineData("#{@a}", "@a=Foo", "Foo")]
+        [InlineData("#{a@b}", "a@b=Foo", "Foo")]
         public void AwkwardCharacters(string template, string variableDefinitions, string expectedResult)
         {
             var result = ParseVariables(variableDefinitions).Evaluate(template);

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -13,7 +13,7 @@ namespace Octostache.Templates
     public static class TemplateParser
     {
         static readonly Parser<Identifier> Identifier = Parse
-            .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
+            .Char(c => char.IsLetter(c) || char.IsDigit(c) || char.IsWhiteSpace(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')' || c == '@', "identifier")
             .Except(Parse.WhiteSpace.FollowedBy("|"))
             .Except(Parse.WhiteSpace.FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()
@@ -23,7 +23,7 @@ namespace Octostache.Templates
             .WithPosition();
 
         static readonly Parser<Identifier> IdentifierWithoutWhitespace = Parse
-            .Char(c => char.IsLetter(c) || char.IsDigit(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')', "identifier")
+            .Char(c => char.IsLetter(c) || char.IsDigit(c) || c == '_' || c == '-' || c == ':' || c == '/' || c == '~' || c == '(' || c == ')' || c == '@', "identifier")
             .Except(Parse.WhiteSpace.FollowedBy("|"))
             .Except(Parse.WhiteSpace.FollowedBy("}"))
             .ExceptWhiteSpaceBeforeKeyword()


### PR DESCRIPTION
Fixes #90

## Problem

A variable whose name contains an `@` cannot be referenced. `#{@foo}` is echoed back unsubstituted, because `@` is not in the character set accepted by the identifier parsers in `TemplateParser`.

This came in from a [customer report](https://help.octopus.com/t/octostashe-reference-json-property-named-with-an-symbol/28724/3) about JSON-LD style property names — `#{Test.@type}` against a `{"@type": "Widget"}` payload does not resolve.

## Fix

Add `@` to both `Identifier` and `IdentifierWithoutWhitespace`. This covers plain variable names, dotted JSON paths, and indexer syntax in one change.

`@` has no other meaning in the Octostache grammar, so the blast radius is limited to names that previously failed to parse. Consistent with the existing precedent of allowing `_ - : / ~ ( )`.

## Tests

- `UsageFixture.AwkwardCharacters`: `#{@a}` and `#{a@b}`
- `JsonFixture.SuccessfulJsonParsing`: `#{Test.@type}` and `#{Test[@type]}` against `{"@type": "Widget"}`

Full suite green: 618 passed on net10.0. No existing test changed behaviour.

## Note

This does not close out the broader question in #53 about arbitrary special characters in variable names — that one still needs a decision on the exclusion set and on parser performance over large documents. This is just the `@` case.