### PR TITLE
Add an optional Truncate suffix

### DIFF
--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -682,11 +682,19 @@ namespace Octostache.Tests
         }
 
         [Fact]
-        public void SubstringHandlesLengthIndexOutOfRange()
+        public void SubstringLengthBeyondEndReturnsWholeString()
         {
             var result = Evaluate(@"#{foo | Substring 20}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } })
                 .Replace("\"", ""); // function parameters have quotes added when evaluated back to a string, so we need to remove them
-            result.Should().Be("#{foo | Substring 20}");
+            result.Should().Be("Octopus Deploy");
+        }
+
+        [Fact]
+        public void SubstringStartAtEndOfStringReturnsEmpty()
+        {
+            var result = Evaluate(@"#{foo | Substring 14 5}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } })
+                .Replace("\"", ""); // function parameters have quotes added when evaluated back to a string, so we need to remove them
+            result.Should().Be("");
         }
 
         [Fact]
@@ -758,6 +766,27 @@ namespace Octostache.Tests
         {
             var result = Evaluate(@"#{foo | Truncate 7}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
             result.Should().Be("Octopus...");
+        }
+
+        [Fact]
+        public void TruncateAppliesACustomSuffix()
+        {
+            var result = Evaluate(@"#{foo | Truncate 7 ""<|>""}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
+            result.Should().Be("Octopus<|>");
+        }
+
+        [Fact]
+        public void TruncateWithAnEmptySuffixOmitsTheEllipsis()
+        {
+            var result = Evaluate(@"#{foo | Truncate 7 """"}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
+            result.Should().Be("Octopus");
+        }
+
+        [Fact]
+        public void TruncateDoesNotApplyTheSuffixWhenNothingIsTruncated()
+        {
+            var result = Evaluate(@"#{foo | Truncate 50 ""<|>""}", new Dictionary<string, string> { { "foo", "Octopus Deploy" } });
+            result.Should().Be("Octopus Deploy");
         }
 
         [Fact]

--- a/source/Octostache/Templates/Functions/TextManipulationFunction.cs
+++ b/source/Octostache/Templates/Functions/TextManipulationFunction.cs
@@ -112,14 +112,15 @@ namespace Octostache.Templates.Functions
 
         public static string? Truncate(string? argument, string[] options)
         {
-            if (argument == null || !options.Any() || !int.TryParse(options[0], out _) || int.Parse(options[0]) < 0)
+            if (argument == null || !options.Any() || !int.TryParse(options[0], out var length) || length < 0)
             {
                 return null;
             }
 
-            var length = int.Parse(options[0]);
+            // The suffix defaults to an ellipsis for backwards compatibility. Pass "" to omit it.
+            var suffix = options.Length > 1 ? options[1] : "...";
             return length < argument.Length
-                ? $"{argument.Substring(0, length)}..."
+                ? $"{argument.Substring(0, length)}{suffix}"
                 : argument;
         }
 

--- a/source/Octostache/Templates/Functions/TextSubstringFunction.cs
+++ b/source/Octostache/Templates/Functions/TextSubstringFunction.cs
@@ -13,17 +13,15 @@ namespace Octostache.Templates.Functions
             if (options.Any(o => !int.TryParse(o, out _)) || options.Any(o => int.Parse(o) < 0))
                 return null;
 
-            if (options.Length == 1 && int.Parse(options[0]) > argument.Length)
-                return null;
-
-            if (options.Length == 2 && int.Parse(options[0]) > argument.Length)
-                return null;
-
             var startIndex = options.Length == 1 ? 0 : int.Parse(options[0]);
             var length = options.Length == 1 ? int.Parse(options[0]) : int.Parse(options[1]);
 
-            // If starting position is valid but the length would exceed the string, use the remaining length of the string
-            if (startIndex < argument.Length && startIndex + length > argument.Length)
+            // A start position past the end of the string is not a request we can honour
+            if (startIndex > argument.Length)
+                return null;
+
+            // Asking for more characters than remain yields whatever is left of the string
+            if (startIndex + length > argument.Length)
                 length = argument.Length - startIndex;
 
             return argument.Substring(startIndex, length);


### PR DESCRIPTION
Refs #93. Alternative to #108 that keeps `Truncate` non-breaking.

`Truncate` always appends `...`, so it cannot bound a string to a known length. Instead of changing that default, it takes an optional second argument for the suffix.

| Template | Before | After |
|---|---|---|
| `#{foo \| Truncate 7}` | `Octopus...` | `Octopus...` (unchanged) |
| `#{foo \| Truncate 7 ""}` | `Octopus...` | `Octopus` |
| `#{foo \| Truncate 7 "<\|>"}` | `Octopus...` | `Octopus<\|>` |
| `#{foo \| Substring 20}` | `#{foo \| Substring 20}` | `Octopus Deploy` |

The `Substring` change also fixes an off-by-one: a start index equal to the string length threw an unhandled `ArgumentOutOfRangeException` (`#{foo | Substring 14 5}` against a 14 character value). The guard used `>` where the following clamp assumed `>=`.

## Breaking?

`Truncate`, no. Two `Substring` tests changed, since returning the unresolved template is a failure mode rather than a capability. A start index genuinely past the end still leaves the template unresolved, consistent with the other invalid-argument cases.

618 tests pass on net10.0.