### PR TITLE
Expose the index as `Key` when iterating indexed collections

### DIFF
--- a/source/Octostache.Tests/IterationFixture.cs
+++ b/source/Octostache.Tests/IterationFixture.cs
@@ -135,5 +135,106 @@ namespace Octostache.Tests
 
             result.Should().Be("container[0]: A container[1]: B container[2]: C ");
         }
+
+        [Fact]
+        public void KeyIsAvailableWhenIndexedCollectionHasDirectValues()
+        {
+            var result = Evaluate("#{each x in Simple}[#{x.Key}]#{/each}",
+                new Dictionary<string, string>
+                {
+                    { "Simple[a]", "5" },
+                    { "Simple[b]", "7" },
+                });
+
+            result.Should().Be("[a][b]");
+        }
+
+        [Fact]
+        public void KeyIsAvailableWhenIndexedCollectionHasOnlySubProperties()
+        {
+            var result = Evaluate("#{each x in NoDirect}[#{x.Key}]#{/each}",
+                new Dictionary<string, string>
+                {
+                    { "NoDirect[a].Name", "Alpha" },
+                    { "NoDirect[b].Name", "Beta" },
+                });
+
+            result.Should().Be("[a][b]");
+        }
+
+        [Fact]
+        public void KeyIsAvailableAlongsideSubPropertiesForCertificateShapedCollections()
+        {
+            var result = Evaluate("#{each x in Cert}[#{x.Key}=#{x.Thumbprint}]#{/each}",
+                new Dictionary<string, string>
+                {
+                    { "Cert[a]", "Certificate-1" },
+                    { "Cert[a].Thumbprint", "AAA" },
+                    { "Cert[b]", "Certificate-2" },
+                    { "Cert[b].Thumbprint", "BBB" },
+                });
+
+            result.Should().Be("[a=AAA][b=BBB]");
+        }
+
+        [Theory]
+        [InlineData("#{each x in Simple}[#{x}]#{/each}", "[5][7]")]
+        [InlineData("#{each x in NoDirect}[#{x}]#{/each}", "[a][b]")]
+        [InlineData("#{each x in Cert}[#{x}]#{/each}", "[Certificate-1][Certificate-2]")]
+        public void BareIterationVariableIsUnaffectedByTheKeyBinding(string template, string expected)
+        {
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "Simple[a]", "5" },
+                    { "Simple[b]", "7" },
+                    { "NoDirect[a].Name", "Alpha" },
+                    { "NoDirect[b].Name", "Beta" },
+                    { "Cert[a]", "Certificate-1" },
+                    { "Cert[a].Thumbprint", "AAA" },
+                    { "Cert[b]", "Certificate-2" },
+                    { "Cert[b].Thumbprint", "BBB" },
+                });
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void UserDefinedKeyVariableOverridesTheSynthesizedKey()
+        {
+            var result = Evaluate("#{each x in Coll}[#{x.Key}]#{/each} #{Coll[a].Key}",
+                new Dictionary<string, string>
+                {
+                    { "Coll[a]", "val-a" },
+                    { "Coll[a].Key", "user-supplied" },
+                });
+
+            result.Should().Be("[user-supplied] user-supplied");
+        }
+
+        [Fact]
+        public void UserDefinedKeyVariableOverridesTheSynthesizedKeyRegardlessOfDeclarationOrder()
+        {
+            var result = Evaluate("#{each x in Coll}[#{x.Key}]#{/each}",
+                new Dictionary<string, string>
+                {
+                    { "Coll[a].Key", "user-supplied" },
+                    { "Coll[a].Name", "Alpha" },
+                });
+
+            result.Should().Be("[user-supplied]");
+        }
+
+        [Fact]
+        public void KeyAndValueRemainAvailableForJsonBackedCollections()
+        {
+            var result = Evaluate("#{each x in Json}[#{x.Key}=#{x.Value}]#{/each}",
+                new Dictionary<string, string>
+                {
+                    { "Json", "{\"a\": \"AAA\", \"b\": \"BBB\"}" },
+                });
+
+            result.Should().Be("[a=AAA][b=BBB]");
+        }
     }
 }

--- a/source/Octostache/Templates/PropertyListBinder.cs
+++ b/source/Octostache/Templates/PropertyListBinder.cs
@@ -49,6 +49,14 @@ namespace Octostache.Templates
                     if (!result.Indexable.TryGetValue(ix.Index, out next))
                     {
                         result.Indexable[ix.Index] = next = new Binding(ix.Index);
+
+                        // Expose the index as a `Key` child binding so `#{x.Key}` works when iterating
+                        // an indexed collection, matching how JSON-backed collections behave. The seeded
+                        // `Item` above is overwritten whenever a value is assigned directly at the index
+                        // (e.g. certificate variables), so `#{x}` alone cannot be relied on for the key.
+                        // A user-defined `Collection[index].Key` variable will find this binding and
+                        // overwrite its `Item`, so real variable data always wins.
+                        next["Key"] = new Binding(ix.Index);
                     }
 
                     break;


### PR DESCRIPTION
Fixes #66

When iterating an indexed variable collection there was no reliable way to get at the key.

## Root cause

`PropertyListBinder.Add()` seeds the indexer binding's `Item` with the index (`new Binding(ix.Index)`), but the subsequent recursive `Add(next, [], value)` **overwrites that `Item`** whenever the variable set has a value assigned directly at `Collection[key]`. So the key survives only by accident — when nothing is assigned at the index. Certificate variables always assign the certificate ID there, so their key is always lost. That is exactly the scenario in the issue.

## Before / after

Probed against `master`, then against this branch:

| Variables | Template | Before | After |
| --- | --- | --- | --- |
| `Simple[a]=5`, `Simple[b]=7` | `#{each x in Simple}[#{x}]#{/each}` | `[5][7]` | `[5][7]` |
| `Simple[a]=5`, `Simple[b]=7` | `#{each x in Simple}[#{x.Key}]#{/each}` | *unresolved* — echoes `[#{x.Key}]` | `[a][b]` |
| `NoDirect[a].Name=Alpha`, … | `#{each x in NoDirect}[#{x}]#{/each}` | `[a][b]` | `[a][b]` |
| `NoDirect[a].Name=Alpha`, … | `#{each x in NoDirect}[#{x.Key}]#{/each}` | *unresolved* | `[a][b]` |
| `Cert[a]=Certificate-1`, `Cert[a].Thumbprint=AAA`, … | `#{each x in Cert}[#{x}]#{/each}` | `[Certificate-1][Certificate-2]` | `[Certificate-1][Certificate-2]` |
| `Cert[a]=Certificate-1`, `Cert[a].Thumbprint=AAA`, … | `#{each x in Cert}[#{x.Key}=#{x.Thumbprint}]#{/each}` | *unresolved key* | `[a=AAA][b=BBB]` |
| JSON-backed collection | `#{x.Key}` / `#{x.Value}` | both work | both work |

Bare `#{x}` is byte-for-byte unchanged in all three shapes — templates in the wild depend on it, so there is an explicit regression guard for each.

## JSON parity

`JsonParser.TryParseJObject(JObject, out Binding[])` already attaches `Key` and `Value` child bindings to every element, so `#{x.Key}` has always worked when iterating a JSON-backed collection but never for an indexed one. This closes that asymmetry: the indexer branch now also attaches a `Key` child binding holding the index.

## `.Value` is deliberately out of scope

The value isn't known at that point in the walk and would need a post-pass over the built binding tree. `#{x}` already returns the value whenever one exists, so `.Value` buys little for the extra machinery. Only `Key` is implemented here.

## User data still wins

A user could legitimately have a variable named `Collection[a].Key`. Because `Add()` does `if (!result.TryGetValue(iss.Text, out next))`, a user-defined `Collection[a].Key` finds the pre-seeded binding and sets its `Item` — it is not shadowed. Verified explicitly, in both declaration orders:

- `Coll[a]=val-a` + `Coll[a].Key=user-supplied` → `#{x.Key}` is `user-supplied`, and `#{Coll[a].Key}` is `user-supplied`
- `Coll[a].Key=user-supplied` declared before `Coll[a].Name` → `#{x.Key}` is still `user-supplied`

## Tests

9 new tests in `IterationFixture`. Suite goes 614 → 623, all passing. No existing test was modified.

## Docs follow-up

The Octopus docs describe `#{x}` as yielding the key when iterating an indexed collection. That is only true when no value is assigned directly at the index — with `Simple[a]=5` or a certificate variable it yields the value. Worth a docs correction alongside this, pointing at `#{x.Key}` as the reliable way to get the key.
