### PR TITLE
Add #{elseif} support to conditionals

### DIFF
--- a/source/Octostache.Tests/ConditionalsFixture.cs
+++ b/source/Octostache.Tests/ConditionalsFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Octostache.Templates;
 using Xunit;
 
 namespace Octostache.Tests
@@ -222,6 +223,236 @@ namespace Octostache.Tests
                 });
 
             result.Should().Be("elseresult");
+        }
+
+        [Fact]
+        public void ElseIfIsSupportedWhenTheElseIfBranchIsTaken()
+        {
+            var result = Evaluate("#{if First}#{FirstResult}#{elseif Second}#{SecondResult}#{else}#{ElseResult}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "FirstResult", "first" },
+                    { "SecondResult", "second" },
+                    { "ElseResult", "else" },
+                    { "First", "false" },
+                    { "Second", "true" },
+                });
+
+            result.Should().Be("second");
+        }
+
+        [Fact]
+        public void ElseIfIsSkippedWhenTheIfBranchIsTaken()
+        {
+            var result = Evaluate("#{if First}#{FirstResult}#{elseif Second}#{SecondResult}#{else}#{ElseResult}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "FirstResult", "first" },
+                    { "SecondResult", "second" },
+                    { "ElseResult", "else" },
+                    { "First", "true" },
+                    { "Second", "true" },
+                });
+
+            result.Should().Be("first");
+        }
+
+        [Fact]
+        public void ElseIfFallsThroughToElseWhenNothingMatches()
+        {
+            var result = Evaluate("#{if First}#{FirstResult}#{elseif Second}#{SecondResult}#{else}#{ElseResult}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "FirstResult", "first" },
+                    { "SecondResult", "second" },
+                    { "ElseResult", "else" },
+                    { "First", "false" },
+                    { "Second", "false" },
+                });
+
+            result.Should().Be("else");
+        }
+
+        [Theory]
+        [InlineData("Development", "dev")]
+        [InlineData("Test", "test")]
+        [InlineData("Staging", "staging")]
+        [InlineData("Production", "prod")]
+        [InlineData("Sandbox", "other")]
+        public void ChainedElseIfClausesOnlyRenderTheFirstMatchingBranch(string environment, string expected)
+        {
+            var result = Evaluate("#{if Environment == \"Development\"}dev"
+                + "#{elseif Environment == \"Test\"}test"
+                + "#{elseif Environment == \"Staging\"}staging"
+                + "#{elseif Environment == \"Production\"}prod"
+                + "#{else}other#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "Environment", environment },
+                });
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void ElseIfWithNoElseRendersNothingWhenNothingMatches()
+        {
+            var result = Evaluate("#{if First}#{FirstResult}#{elseif Second}#{SecondResult}#{elseif Third}#{ThirdResult}#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "FirstResult", "first" },
+                    { "SecondResult", "second" },
+                    { "ThirdResult", "third" },
+                    { "First", "false" },
+                    { "Second", "false" },
+                    { "Third", "false" },
+                });
+
+            result.Should().Be("");
+        }
+
+        [Theory]
+        [InlineData("#{if First}first#{elseif Octopus == \"octopus\"}second#{else}third#{/if}", "second")]
+        [InlineData("#{if First}first#{elseif Octopus != \"octopus\"}second#{else}third#{/if}", "third")]
+        [InlineData("#{if First}first#{elseif \"octopus\" == Octopus}second#{else}third#{/if}", "second")]
+        [InlineData("#{if First}first#{elseif Octopus == Compare}second#{else}third#{/if}", "second")]
+        [InlineData("#{if First}first#{elseif Second}second#{else}third#{/if}", "third")]
+        [InlineData("#{if First}first#{elseif Third}second#{else}third#{/if}", "second")]
+        [InlineData("#{if First}first#{elseif Octopus | ToUpper == \"OCTOPUS\"}second#{/if}", "second")]
+        public void ElseIfSupportsTheSameConditionsAsIf(string template, string expected)
+        {
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "First", "false" },
+                    { "Second", "false" },
+                    { "Third", "true" },
+                    { "Octopus", "octopus" },
+                    { "Compare", "octopus" },
+                });
+
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("#{if First}first#{elseif  Second}second#{/if}")]
+        [InlineData("#{if First}first#{elseif Second }second#{/if}")]
+        [InlineData("#{if First}first#{elseif  Second  }second#{/if}")]
+        [InlineData("#{if First}first#{elseif Second  ==  \"true\"}second#{/if}")]
+        public void ElseIfIgnoresWhitespacesCorrectly(string template)
+        {
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "First", "false" },
+                    { "Second", "true" },
+                });
+
+            result.Should().Be("second");
+        }
+
+        [Fact]
+        public void NestedConditionalsInsideAnElseIfBranchAreSupported()
+        {
+            var result = Evaluate("#{if First}first#{elseif Second}#{if Fooey == \"foo\"}nested#{else}notnested#{/if}#{else}else#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "First", "false" },
+                    { "Second", "true" },
+                    { "Fooey", "foo" },
+                });
+
+            result.Should().Be("nested");
+        }
+
+        [Fact]
+        public void NestedElseIfChainsInsideAnElseIfBranchAreSupported()
+        {
+            var result = Evaluate("#{if First}first#{elseif Second}#{if Third}third#{elseif Fourth}fourth#{else}none#{/if}#{else}else#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "First", "false" },
+                    { "Second", "true" },
+                    { "Third", "false" },
+                    { "Fourth", "true" },
+                });
+
+            result.Should().Be("fourth");
+        }
+
+        [Theory]
+        [InlineData("Development", "dev")]
+        [InlineData("Test", "test")]
+        [InlineData("Production", "other")]
+        public void ElseIfIsSupportedAcrossMultipleLines(string environment, string expected)
+        {
+            var template = "#{if Octopus.Environment.Name == \"Development\"}dev"
+                + Environment.NewLine
+                + "#{elseif Octopus.Environment.Name == \"Test\"}test"
+                + Environment.NewLine
+                + "#{else}other"
+                + Environment.NewLine
+                + "#{/if}";
+
+            var result = Evaluate(template,
+                new Dictionary<string, string>
+                {
+                    { "Octopus.Environment.Name", environment },
+                });
+
+            result.Should().Be(expected + Environment.NewLine);
+        }
+
+        [Fact]
+        public void ElseIfIsSupportedWhenNotHaltingOnErrors()
+        {
+            var result = Evaluate("#{if First}first#{elseif Second}second#{else}else#{/if}",
+                new Dictionary<string, string>
+                {
+                    { "First", "false" },
+                    { "Second", "true" },
+                },
+                false);
+
+            result.Should().Be("second");
+        }
+
+        [Fact]
+        public void ElseIfIsNotSupportedInsideUnless()
+        {
+            var parsed = TemplateParser.TryParseTemplate("#{unless First}first#{elseif Second == \"x\"}second#{/unless}", out _, out _);
+
+            parsed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ElseIfDesugarsToNestedConditionals()
+        {
+            // The parser folds an elseif chain into nested conditionals, so the round trip through ToString()
+            // renders the equivalent nested #{if}s rather than the original elseif text.
+            var template = TemplateParser.ParseTemplate("#{if First}first#{elseif Second}second#{else}else#{/if}");
+
+            template.ToString().Should().Be("#{if First}first#{else}#{if Second}second#{else}else#{/if}#{/if}");
+        }
+
+        [Fact]
+        public void ArgumentNamesAreExtractedFromElseIfConditionsAndBranches()
+        {
+            var result = TemplateParser.ParseTemplateAndGetArgumentNames("#{if first}#{firstResult}"
+                + "#{elseif second == \"value\"}#{secondResult}"
+                + "#{elseif third}#{thirdResult}"
+                + "#{else}#{elseResult}#{/if}");
+
+            result.Should().Contain(new[]
+            {
+                "first",
+                "firstResult",
+                "second",
+                "secondResult",
+                "third",
+                "thirdResult",
+                "elseResult",
+            });
         }
 
         [Fact]

--- a/source/Octostache/Templates/TemplateParser.cs
+++ b/source/Octostache/Templates/TemplateParser.cs
@@ -35,6 +35,14 @@ namespace Octostache.Templates
         static readonly Parser<string> LDelim = Parse.String("#{").Except(Parse.String("#{/")).Text();
         static readonly Parser<string> RDelim = Parse.String("}").Text();
 
+        // The opening of an `#{elseif <expression>}` clause. Unlike `#{else}` this is only a prefix, as the
+        // expression follows it, so we require the trailing whitespace to avoid capturing something like
+        // `#{elseifSomeVariable}` which is a perfectly valid substitution today.
+        static readonly Parser<char> ElseIfDelim =
+            from leftDelim in Parse.String("#{elseif")
+            from sp in Parse.WhiteSpace
+            select sp;
+
         static readonly Parser<SubstitutionToken> Substitution =
             (from leftDelim in LDelim
                 from expression in Expression.Token()
@@ -118,15 +126,30 @@ namespace Octostache.Templates
                 from expression in ExpressionsMatch.Token().Or(LeftStringMatch.Token()).Or(RightStringMatch.Token()).Or(TruthyMatch.Token())
                 from sp2 in Parse.WhiteSpace.Many()
                 from rightDelim in RDelim
-                from truthy in Parse.Ref(() => IfTemplate)
+                // `#{elseif}` is only supported for `#{if}`. `#{unless}` swaps the truthy and falsy branches which
+                // would make the meaning of an `elseif` chain ambiguous, so it keeps its original grammar.
+                from truthy in kw == "if" ? Parse.Ref(() => IfTemplate) : Parse.Ref(() => UnlessTemplate)
+                from elseIfs in kw == "if" ? Parse.Ref(() => ElseIfClauses) : Parse.Return(Enumerable.Empty<ElseIfClause>())
                 from elseMatch in
                     (from el in Parse.String("#{else}")
                         from template in Parse.Ref(() => Template)
                         select template).Optional()
                 from end in Parse.String("#{/" + kw + "}")
-                let falsey = elseMatch.IsDefined ? elseMatch.Get() : Enumerable.Empty<TemplateToken>()
+                let elseTemplate = elseMatch.IsDefined ? elseMatch.Get() : Enumerable.Empty<TemplateToken>()
+                let falsey = FoldElseIfClauses(elseIfs, elseTemplate)
                 select kw == "if" ? new ConditionalToken(expression, truthy, falsey) : new ConditionalToken(expression, falsey, truthy))
             .WithPosition();
+
+        static readonly Parser<ElseIfClause> ElseIf =
+            (from elseIfDelim in ElseIfDelim
+                from expression in ExpressionsMatch.Token().Or(LeftStringMatch.Token()).Or(RightStringMatch.Token()).Or(TruthyMatch.Token())
+                from sp in Parse.WhiteSpace.Many()
+                from rightDelim in RDelim
+                from truthy in Parse.Ref(() => IfTemplate)
+                select new ElseIfClause(expression, truthy))
+            .WithPosition();
+
+        static readonly Parser<IEnumerable<ElseIfClause>> ElseIfClauses = ElseIf.Many();
 
         static readonly Parser<CalculationToken> Calculation =
             (from leftDelim in LDelim
@@ -252,7 +275,12 @@ namespace Octostache.Templates
         static readonly Parser<TemplateToken[]> Template =
             Token.Many().Select(tokens => tokens.ToArray());
 
+        // The body of an `#{if}` or an `#{elseif}` clause: it ends at the next `#{elseif`, the `#{else}` or the `#{/if}`.
         static readonly Parser<TemplateToken[]> IfTemplate =
+            Token.Except(Parse.String("#{else}")).Except(ElseIfDelim).Many().Select(tokens => tokens.ToArray());
+
+        // The body of an `#{unless}`, which does not support `#{elseif}`.
+        static readonly Parser<TemplateToken[]> UnlessTemplate =
             Token.Except(Parse.String("#{else}")).Many().Select(tokens => tokens.ToArray());
 
         static readonly Parser<TemplateToken[]> ContinueOnErrorsTemplate =
@@ -263,6 +291,27 @@ namespace Octostache.Templates
         static readonly ItemCache<SymbolExpression> PathCache = new ItemCache<SymbolExpression>("OctostachePath", 100, TimeSpan.FromMinutes(10));
 
         static Parser<CalculationOperator> CalculationOperator(string op, CalculationOperator @operator) => Parse.String(op).Token().Return(@operator);
+
+        /// <summary>
+        /// Desugars an `#{elseif}` chain by folding the clauses right-to-left into nested conditionals, each one
+        /// living in the falsy branch of the clause before it. The resulting tree is identical to the one produced
+        /// by hand-nesting an `#{if}` inside an `#{else}`, so nothing downstream of the parser needs to know that
+        /// `#{elseif}` exists.
+        /// </summary>
+        static IEnumerable<TemplateToken> FoldElseIfClauses(IEnumerable<ElseIfClause> clauses, IEnumerable<TemplateToken> elseTemplate)
+        {
+            var falsey = elseTemplate;
+            foreach (var clause in clauses.Reverse())
+            {
+                var conditional = new ConditionalToken(clause.Expression, clause.Template, falsey)
+                {
+                    InputPosition = clause.InputPosition,
+                };
+                falsey = new TemplateToken[] { conditional };
+            }
+
+            return falsey;
+        }
 
         static Parser<T> FollowedBy<T>(this Parser<T> parser, string lookahead)
         {
@@ -446,6 +495,26 @@ namespace Octostache.Templates
         {
             public Template? Result { get; set; }
             public string? Error { get; set; }
+        }
+
+        /// <summary>
+        /// A single parsed `#{elseif expression}template` clause. This never escapes the parser: it is folded into a
+        /// nested <see cref="ConditionalToken" /> by <see cref="FoldElseIfClauses" />.
+        /// </summary>
+        class ElseIfClause : IInputToken
+        {
+            public Position? InputPosition { get; set; }
+            public ConditionalExpressionToken Expression { get; }
+            public TemplateToken[] Template { get; }
+
+            public ElseIfClause(ConditionalExpressionToken expression, TemplateToken[] template)
+            {
+                Expression = expression;
+                Template = template;
+            }
+
+            public IEnumerable<string> GetArguments() =>
+                Expression.GetArguments().Concat(Template.SelectMany(t => t.GetArguments()));
         }
     }
 }


### PR DESCRIPTION
Fixes #92

Adds `#{elseif <expression>}` to the template language so conditions can be chained without nesting an `#{if}` inside every `#{else}`.

Before:

```
#{if Octopus.Environment.Name == "Development"}dev
#{else}#{if Octopus.Environment.Name == "Test"}test
#{else}other
#{/if}#{/if}
```

After:

```
#{if Octopus.Environment.Name == "Development"}dev
#{elseif Octopus.Environment.Name == "Test"}test
#{else}other
#{/if}
```

### How it works

`#{elseif}` is desugared entirely in `TemplateParser`. Zero or more `#{elseif <expr>}<template>` clauses are parsed, then folded right-to-left into nested `ConditionalToken`s placed in the falsy branch of the preceding conditional. The resulting tree is structurally identical to what a hand-nested template produces today, so `TemplateEvaluator`, `ConditionalToken`, `TemplateAnalyzer` and `GetArguments()` all needed no changes — they already recurse through both branches.

The elseif condition reuses the same expression alternation as `#{if}`, so `==`/`!=`, string literals on either side, filter chains and plain truthy checks all work.

### Notes

- **`ToString()` round trip**: because the desugaring happens in the parser, `ToString()` on a parsed elseif renders the equivalent nested `#{if}`s rather than the original `elseif` text. `ParserFixture.ParsedTemplateIsConvertibleBackToString` still passes; the behaviour is pinned by a new test.
- **`#{unless}` is deliberately excluded.** `#{unless}` swaps the truthy and falsy branches, which would make the meaning of an elseif chain ambiguous. It keeps its original grammar (`UnlessTemplate`), so nothing about `#{unless}` parsing changes.
- **Non-breaking.** The `#{elseif` lookahead requires trailing whitespace, so an existing substitution such as `#{elseifSomething}` is untouched. `#{elseif ...}` was not previously usable as an elseif, so no existing template can depend on the old behaviour. Both the `haltOnError: true` and `haltOnError: false` (`ContinueOnErrorsTemplate`) paths are covered.

### Tests

29 new tests in `ConditionalsFixture` covering: elseif taken / skipped / falling through to `#{else}`, chained clauses (4 deep) rendering only the first match, no trailing `#{else}`, all the supported condition forms, whitespace handling, nested `#{if}` and nested elseif chains inside an elseif branch, multi-line templates, the `haltOnError: false` path, `#{unless}` rejecting elseif, the desugaring shape, and argument-name extraction.

Suite: 614 passing before, 643 passing after, no existing test modified.
