### PR TITLE
Move to FluentAssertions 7.2.2 and pin below 8.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       time: "09:00"
       timezone: "Pacific/Auckland"
     open-pull-requests-limit: 2
+    ignore:
+      # FluentAssertions 8.0.0 moved to a paid commercial licence. Staying on 7.x
+      # is a licensing decision rather than a routine upgrade, so don't raise it
+      # automatically. Note this is an explicit version range and not
+      # `version-update:semver-major`, which would also block 5.x/6.x/7.x.
+      - dependency-name: "FluentAssertions"
+        versions: [">=8.0.0"]

--- a/source/Octostache.Tests/FiltersFixture.cs
+++ b/source/Octostache.Tests/FiltersFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -361,7 +361,7 @@ namespace Octostache.Tests
         public void NowDateReturnsNow()
         {
             var result = Evaluate("#{ | NowDate}", new Dictionary<string, string>());
-            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now, 60000);
+            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now, TimeSpan.FromMilliseconds(60000));
         }
 
         [Fact]
@@ -389,7 +389,7 @@ namespace Octostache.Tests
         public void NowDateReturnsNowInUtc()
         {
             var result = Evaluate("#{ | NowDateUtc}", new Dictionary<string, string>());
-            DateTimeOffset.Parse(result).Should().BeCloseTo(DateTimeOffset.UtcNow, 60000);
+            DateTimeOffset.Parse(result).Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(60000));
         }
 
         [Fact]
@@ -480,7 +480,7 @@ namespace Octostache.Tests
         public void AddHoursCanBeChainedOffNowDate()
         {
             var result = Evaluate("#{ | NowDate | AddHours 2}", new Dictionary<string, string>());
-            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now.AddHours(2), 60000);
+            DateTime.Parse(result).Should().BeCloseTo(DateTime.Now.AddHours(2), TimeSpan.FromMilliseconds(60000));
         }
 
         [Fact]

--- a/source/Octostache.Tests/Octostache.Tests.csproj
+++ b/source/Octostache.Tests/Octostache.Tests.csproj
@@ -36,7 +36,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="4.19.2"/>
+        <PackageReference Include="FluentAssertions" Version="[7.2.2,8.0.0)"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="Sprache" Version="2.3.1"/>


### PR DESCRIPTION
Supersedes the Dependabot attempts in #133, #103 and #75.

The test project has been on FluentAssertions **4.19.2** for years. Every Dependabot attempt to move it has failed to build for the same reason: 6.x changed `BeCloseTo`'s tolerance parameter from `int` milliseconds to a `TimeSpan`, and Dependabot only edits the `.csproj` — it can never fix the three call sites, so those PRs can never go green on their own.

```
FiltersFixture.cs:364, :392, :483   cannot convert from 'int' to 'System.TimeSpan'
```

That is the entire compatibility gap. With those three lines fixed, all 614 tests pass on 7.2.2.

## Why 7.2.2 and not 8.10.0

FluentAssertions 8.0.0 moved to a paid commercial licence, so #133's jump to 8.10.0 is a procurement decision rather than a routine bump. 7.2.2 is the newest release under the old terms.

## Why a range and not a version

`Version="7.2.2"` in NuGet means **>= 7.2.2**, not a pin — a transitive reference could still float onto 8.x. `[7.2.2,8.0.0)` allows 7.x patches and hard-blocks 8.0.0+. Verified in `project.assets.json`.

The matching Dependabot `ignore` rule uses an explicit `>=8.0.0` range rather than `version-update:semver-major`, because the latter would have blocked this very upgrade while the project sat on 4.19.2.

## Notes

- `Octopus.Versioning` needs nothing — `master` is already on 5.1.882, ahead of the 5.1.876 that closed PR #104 proposed.
- Only verified on net10.0; net48 builds on Windows only. FluentAssertions 7.2.2 targets net47+, so it should be fine, but CI is the real check here.
- #134 (gitversion.tool) is untouched and still open.