### PR TITLE
Add an RsaEncrypt filter that takes a public key

### DIFF
--- a/source/Octostache.Tests/EncryptionFixture.cs
+++ b/source/Octostache.Tests/EncryptionFixture.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Octostache.Tests
+{
+    public class EncryptionFixture : BaseFixture
+    {
+        [Fact]
+        public void MissingArgumentIsReported()
+        {
+            var result = Evaluate("#{foo | RsaEncrypt}", new Dictionary<string, string> { { "foo", "Test" } });
+            result.Should().Be("[RsaEncrypt error: expected a single argument holding a base64 encoded RSA public key]");
+        }
+
+        [Fact]
+        public void TooManyArgumentsAreReported()
+        {
+            var result = Evaluate(@"#{foo | RsaEncrypt abc def}", new Dictionary<string, string> { { "foo", "Test" } });
+            result.Should().Be("[RsaEncrypt error: expected a single argument holding a base64 encoded RSA public key]");
+        }
+
+        [Fact]
+        public void MissingInputLeavesTheTemplateUnevaluated()
+        {
+            var result = Evaluate("#{missing | RsaEncrypt abc}", new Dictionary<string, string>())
+                .Replace("\"", ""); // function parameters have quotes added when evaluated back to a string, so we need to remove them
+            result.Should().Be("#{missing | RsaEncrypt abc}");
+        }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void EncryptionIsReportedAsUnsupportedOnDotNetFramework()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var result = Encrypt("Test", PublicKeyOf(rsa));
+                result.Should().Be("[RsaEncrypt error: not supported when Octostache is running on .NET Framework]");
+            }
+        }
+#else
+        [Fact]
+        public void EncryptedValueRoundTripsWithThePrivateKey()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var result = Encrypt("Test", PublicKeyOf(rsa));
+
+                var plainText = rsa.Decrypt(Convert.FromBase64String(result), RSAEncryptionPadding.OaepSHA256);
+                Encoding.UTF8.GetString(plainText).Should().Be("Test");
+            }
+        }
+
+        [Fact]
+        public void EncryptingTheSameValueTwiceProducesDifferentCipherText()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var publicKey = PublicKeyOf(rsa);
+
+                Encrypt("Test", publicKey).Should().NotBe(Encrypt("Test", publicKey));
+            }
+        }
+
+        [Fact]
+        public void NonBase64PublicKeyIsReported()
+        {
+            var result = Encrypt("Test", "not base64!");
+            result.Should().Be("[RsaEncrypt error: the public key is not valid base64]");
+        }
+
+        [Fact]
+        public void PublicKeyThatIsNotSubjectPublicKeyInfoIsReported()
+        {
+            var result = Encrypt("Test", Convert.ToBase64String(Encoding.UTF8.GetBytes("this is not a key")));
+            result.Should().Be("[RsaEncrypt error: the public key could not be read as a SubjectPublicKeyInfo structure]");
+        }
+
+        [Fact]
+        public void InputLongerThanTheKeyCanEncryptIsReported()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var result = Encrypt(new string('a', 200), PublicKeyOf(rsa));
+                result.Should().Be("[RsaEncrypt error: the input is 200 bytes, which is more than the 190 bytes a 2048 bit key can encrypt directly]");
+            }
+        }
+
+        [Fact]
+        public void InputAtTheLimitOfWhatTheKeyCanEncryptIsAccepted()
+        {
+            using (var rsa = RSA.Create(2048))
+            {
+                var value = new string('a', 190);
+                var result = Encrypt(value, PublicKeyOf(rsa));
+
+                var plainText = rsa.Decrypt(Convert.FromBase64String(result), RSAEncryptionPadding.OaepSHA256);
+                Encoding.UTF8.GetString(plainText).Should().Be(value);
+            }
+        }
+
+        static string PublicKeyOf(RSA rsa) => Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo());
+#endif
+
+        string Encrypt(string value, string publicKey)
+            => Evaluate("#{foo | RsaEncrypt #{key}}",
+                new Dictionary<string, string>
+                {
+                    { "foo", value },
+                    { "key", publicKey },
+                });
+    }
+}

--- a/source/Octostache/Templates/BuiltInFunctions.cs
+++ b/source/Octostache/Templates/BuiltInFunctions.cs
@@ -48,6 +48,7 @@ namespace Octostache.Templates
             { "versionmetadata", VersionParseFunction.VersionMetadata },
             { "append", TextManipulationFunction.Append },
             { "prepend", TextManipulationFunction.Prepend },
+            { "rsaencrypt", TextEncryptFunction.RsaEncrypt },
             { "md5", HashFunction.Md5 },
             { "sha1", HashFunction.Sha1 },
             { "sha256", HashFunction.Sha256 },

--- a/source/Octostache/Templates/Functions/TextEncryptFunction.cs
+++ b/source/Octostache/Templates/Functions/TextEncryptFunction.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Octostache.Templates.Functions
+{
+    static class TextEncryptFunction
+    {
+        // OAEP with SHA-256 costs two hashes plus two bytes of the modulus, leaving the rest for the payload.
+        const int OaepSha256Overhead = (2 * 32) + 2;
+
+        public static string? RsaEncrypt(string? argument, string[] options)
+        {
+            if (argument == null)
+                return null;
+
+            if (options.Length != 1)
+                return Error("expected a single argument holding a base64 encoded RSA public key");
+
+#if NET462
+            return Error("not supported when Octostache is running on .NET Framework");
+#else
+            byte[] subjectPublicKeyInfo;
+            try
+            {
+                subjectPublicKeyInfo = Convert.FromBase64String(options[0]);
+            }
+            catch (FormatException)
+            {
+                return Error("the public key is not valid base64");
+            }
+
+            using (var rsa = RSA.Create())
+            {
+                try
+                {
+                    rsa.ImportSubjectPublicKeyInfo(subjectPublicKeyInfo, out _);
+                }
+                catch (CryptographicException)
+                {
+                    return Error("the public key could not be read as a SubjectPublicKeyInfo structure");
+                }
+
+                var data = Encoding.UTF8.GetBytes(argument);
+                var maximum = (rsa.KeySize / 8) - OaepSha256Overhead;
+                if (data.Length > maximum)
+                    return Error($"the input is {data.Length} bytes, which is more than the {maximum} bytes a {rsa.KeySize} bit key can encrypt directly");
+
+                try
+                {
+                    return Convert.ToBase64String(rsa.Encrypt(data, RSAEncryptionPadding.OaepSHA256));
+                }
+                catch (CryptographicException e)
+                {
+                    return Error(e.Message);
+                }
+            }
+#endif
+        }
+
+        // Encryption failures are reported in the output rather than returned as null, which would leave the
+        // raw `#{...}` in place and read as though no encryption had been asked for. Matches UriPart.
+        static string Error(string message) => $"[RsaEncrypt error: {message}]";
+    }
+}


### PR DESCRIPTION
Refs #39, #38. Draft — the .NET Framework question below needs a decision before this is worth reviewing properly.

Follows droyad's suggestion on #39 that encoding just the public key would be more reusable than passing a whole X509 certificate. That also sidesteps the certificate store and `X509KeyStorageFlags` problem that stalled #38 in 2020.

```
#{Secret | RsaEncrypt #{PublicKey}}
```

Takes a base64 `SubjectPublicKeyInfo`, encrypts with OAEP-SHA256, returns base64.

## What is different from #38

**Failures are loud.** #38 caught every exception and returned `null`, which leaves the raw `#{...}` in the output — indistinguishable from nobody having asked for encryption. This returns `[RsaEncrypt error: ...]`, following the existing `UriPart` precedent:

| Situation | Output |
|---|---|
| Key is not base64 | `[RsaEncrypt error: the public key is not valid base64]` |
| Key is not an SPKI structure | `[RsaEncrypt error: the public key could not be read as a SubjectPublicKeyInfo structure]` |
| Input too large | `[RsaEncrypt error: the input is 200 bytes, which is more than the 190 bytes a 2048 bit key can encrypt directly]` |

**The size ceiling is checked up front.** Direct RSA-OAEP-SHA256 with a 2048 bit key tops out at 190 bytes. #38 would have thrown, swallowed it and silently not encrypted.

**OAEP-SHA256** rather than OAEP-SHA1.

**The tests actually decrypt.** #38 only asserted the result was non-empty, and its cert helper returned `null` outside `NETCOREAPP` so the whole test body was skipped on .NET Framework. These round-trip through the private key and assert the plaintext comes back.

## Open question: .NET Framework

`RSA.ImportSubjectPublicKeyInfo` does not exist on net462, which this library still targets. Right now that path returns `[RsaEncrypt error: not supported when Octostache is running on .NET Framework]`.

The alternatives are hand-rolling SPKI DER parsing for net462, which I would rather not do in a crypto path, or accepting an X509 certificate on that target instead. Worth deciding before this goes further.

## Still true regardless

OAEP is randomised, so the same value encrypts differently every evaluation and a substituted config file will show a diff on every deployment. That is inherent, not a bug, but it should be documented if this lands.

656 tests pass on net10.0. Not verified on net48 — that only builds on Windows.